### PR TITLE
fix(net): add alias and default to param fields

### DIFF
--- a/alioth/src/virtio/dev/net/net.rs
+++ b/alioth/src/virtio/dev/net/net.rs
@@ -107,12 +107,18 @@ pub struct Net {
     feature: NetFeature,
 }
 
+fn default_tap_device() -> PathBuf {
+    PathBuf::from("/dev/net/tun")
+}
+
 #[derive(Deserialize)]
 pub struct NetParam {
     pub mac: MacAddr,
     pub mtu: u16,
     pub queue_pairs: Option<NonZeroU16>,
+    #[serde(default = "default_tap_device")]
     pub tap: PathBuf,
+    #[serde(alias = "if")]
     pub if_name: Option<String>,
 }
 


### PR DESCRIPTION
This gives us the backward compatibility for command line options like `--net if=test-tap,mac=aa:bb:cc:dd:ee:ff,mtu=1500`.

Fixes: 6a66b2d29970 ("feat(cli)!: use serde-aco to parse cli options")