### PR TITLE
Boot AMD-SEV guests with Oak/Stage0

### DIFF
--- a/alioth-cli/src/main.rs
+++ b/alioth-cli/src/main.rs
@@ -86,6 +86,9 @@ struct RunArgs {
 
     #[arg(long)]
     blk: Vec<String>,
+
+    #[arg(long)]
+    coco: Option<String>,
 }
 
 fn main_run(args: RunArgs) -> Result<()> {
@@ -114,10 +117,14 @@ fn main_run(args: RunArgs) -> Result<()> {
     } else {
         None
     };
+    let coco = match args.coco {
+        None => None,
+        Some(c) => Some(serde_aco::from_arg(&c)?),
+    };
     let board_config = BoardConfig {
         mem_size: serde_aco::from_arg(&args.mem_size)?,
         num_cpu: args.num_cpu,
-        coco: None,
+        coco,
     };
     let mut vm = Machine::new(hypervisor, board_config)?;
     #[cfg(target_arch = "x86_64")]

--- a/alioth-cli/src/main.rs
+++ b/alioth-cli/src/main.rs
@@ -117,6 +117,7 @@ fn main_run(args: RunArgs) -> Result<()> {
     let board_config = BoardConfig {
         mem_size: serde_aco::from_arg(&args.mem_size)?,
         num_cpu: args.num_cpu,
+        coco: None,
     };
     let mut vm = Machine::new(hypervisor, board_config)?;
     #[cfg(target_arch = "x86_64")]

--- a/alioth/src/arch/x86_64/sev.rs
+++ b/alioth/src/arch/x86_64/sev.rs
@@ -12,8 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod layout;
-pub mod msr;
-pub mod paging;
-pub mod reg;
-pub mod sev;
+use bitfield::bitfield;
+use serde::{Deserialize, Serialize};
+
+bitfield! {
+    #[derive(Copy, Clone, Serialize, Deserialize)]
+    pub struct Policy(u32);
+    impl Debug;
+    pub no_debug, set_no_debug: 0;
+    pub no_ks, set_no_ks: 1;
+    pub es, set_es: 2;
+    pub no_send, set_no_send: 3;
+    pub domain, set_domain: 4;
+    pub sev, set_sev: 5;
+    pub api_major, set_api_major: 16,23;
+    pub api_minor, set_api_minor: 24,31;
+}

--- a/alioth/src/board/board.rs
+++ b/alioth/src/board/board.rs
@@ -261,11 +261,15 @@ where
                 self.init_boot_vcpu(&mut vcpu, &init_state)?;
                 self.create_firmware_data(&init_state)?;
             }
+            self.init_ap(id, &mut vcpu, &vcpus)?;
             if let Some(coco) = &self.config.coco {
                 match coco {
-                    Coco::AmdSev { .. } => {
+                    Coco::AmdSev { policy } => {
                         self.sync_vcpus(&vcpus);
                         if id == 0 {
+                            if policy.es() {
+                                self.vm.sev_launch_update_vmsa()?;
+                            }
                             self.vm.sev_launch_measure()?;
                             self.vm.sev_launch_finish()?;
                         }

--- a/alioth/src/board/x86_64.rs
+++ b/alioth/src/board/x86_64.rs
@@ -13,13 +13,17 @@
 // limitations under the License.
 
 use std::arch::x86_64::__cpuid;
+use std::mem::size_of;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
+use zerocopy::FromBytes;
 
 use crate::arch::layout::{BIOS_DATA_END, EBDA_END, EBDA_START, MEM_64_START, RAM_32_SIZE};
-use crate::board::{Board, BoardConfig, Result};
-use crate::hv::arch::Cpuid;
+use crate::arch::reg::SegAccess;
+use crate::board::{Board, BoardConfig, Result, VcpuGuard};
+use crate::hv::arch::{Cpuid, Reg, SegReg, SegRegVal};
 use crate::hv::{Coco, Hypervisor, Vcpu, Vm};
 use crate::loader::InitState;
 use crate::mem::mapped::ArcMemPages;
@@ -27,6 +31,7 @@ use crate::mem::{AddrOpt, MemRange, MemRegion, MemRegionEntry, MemRegionType};
 
 pub struct ArchBoard {
     cpuids: Vec<Cpuid>,
+    sev_ap_eip: AtomicU32,
 }
 
 impl ArchBoard {
@@ -47,7 +52,10 @@ impl ArchBoard {
                 }
             }
         }
-        Ok(Self { cpuids })
+        Ok(Self {
+            cpuids,
+            sev_ap_eip: AtomicU32::new(0),
+        })
     }
 }
 
@@ -57,7 +65,11 @@ where
 {
     pub fn setup_firmware(&self, fw: &mut ArcMemPages) -> Result<()> {
         match &self.config.coco {
-            Some(Coco::AmdSev { .. }) => {
+            Some(Coco::AmdSev { policy }) => {
+                if policy.es() {
+                    let ap_eip = get_ap_eip_from_fw(fw.as_slice()).unwrap();
+                    self.arch.sev_ap_eip.store(ap_eip, Ordering::Release);
+                }
                 self.memory.ram_bus().register_encrypted_pages(&fw)?;
                 self.vm.sev_launch_update_data(fw.as_slice_mut())?;
             }
@@ -65,6 +77,36 @@ where
         }
         Ok(())
     }
+
+    pub fn init_ap(&self, id: u32, vcpu: &mut V::Vcpu, vcpus: &VcpuGuard) -> Result<()> {
+        let Some(Coco::AmdSev { policy }) = &self.config.coco else {
+            return Ok(());
+        };
+        if !policy.es() {
+            return Ok(());
+        }
+        self.sync_vcpus(vcpus);
+        if id == 0 {
+            return Ok(());
+        }
+        let eip = self.arch.sev_ap_eip.load(Ordering::Acquire);
+        vcpu.set_regs(&[(Reg::Rip, eip as u64 & 0xffff)])?;
+        vcpu.set_sregs(
+            &[],
+            &[(
+                SegReg::Cs,
+                SegRegVal {
+                    selector: 0xf000,
+                    base: eip as u64 & 0xffff_0000,
+                    limit: 0xffff,
+                    access: SegAccess(0x9b),
+                },
+            )],
+            &[],
+        )?;
+        Ok(())
+    }
+
     pub fn init_boot_vcpu(&self, vcpu: &mut V::Vcpu, init_state: &InitState) -> Result<()> {
         vcpu.set_sregs(&init_state.sregs, &init_state.seg_regs, &init_state.dt_regs)?;
         vcpu.set_regs(&init_state.regs)?;
@@ -128,4 +170,40 @@ where
         }
         Ok(())
     }
+}
+
+const GUID_TABLE_FOOTER_R_OFFSET: usize = 48;
+
+const GUID_SIZE: usize = 16;
+
+const GUID_TABLE_FOOTER_GUID: [u8; GUID_SIZE] = [
+    0xDE, 0x82, 0xB5, 0x96, 0xB2, 0x1F, 0xF7, 0x45, 0xBA, 0xEA, 0xA3, 0x66, 0xC5, 0x5A, 0x08, 0x2D,
+];
+
+const SEV_ES_RESET_BLOCK_GUID: [u8; GUID_SIZE] = [
+    0xde, 0x71, 0xf7, 0x00, 0x7e, 0x1a, 0xcb, 0x4f, 0x89, 0x0e, 0x68, 0xc7, 0x7e, 0x2f, 0xb4, 0x4e,
+];
+
+pub fn get_ap_eip_from_fw(blob: &[u8]) -> Option<u32> {
+    let offset_table_footer = blob.len().checked_sub(GUID_TABLE_FOOTER_R_OFFSET)?;
+    if !blob[offset_table_footer..].starts_with(&GUID_TABLE_FOOTER_GUID) {
+        return None;
+    }
+    let offset_table_len = offset_table_footer.checked_sub(size_of::<u16>())?;
+    let table_len = u16::read_from_prefix(&blob[offset_table_len..])? as usize;
+    let offset_table_end = offset_table_len.checked_sub(
+        table_len
+            .checked_sub(size_of::<u16>())?
+            .checked_sub(GUID_SIZE)?,
+    )?;
+    let mut current = offset_table_len;
+    while current > offset_table_end {
+        let offset_len = current.checked_sub(GUID_SIZE + size_of::<u16>())?;
+        if blob[(offset_len + 2)..].starts_with(&SEV_ES_RESET_BLOCK_GUID) {
+            return u32::read_from_prefix(&blob[offset_len.checked_sub(size_of::<u32>())?..]);
+        }
+        let table_len = u16::read_from_prefix(&blob[offset_len..])? as usize;
+        current = current.checked_sub(table_len)?;
+    }
+    None
 }

--- a/alioth/src/board/x86_64.rs
+++ b/alioth/src/board/x86_64.rs
@@ -48,6 +48,7 @@ where
         match &self.config.coco {
             Some(Coco::AmdSev { .. }) => {
                 self.memory.ram_bus().register_encrypted_pages(&fw)?;
+                self.vm.sev_launch_update_data(fw.as_slice_mut())?;
             }
             None => {}
         }

--- a/alioth/src/board/x86_64.rs
+++ b/alioth/src/board/x86_64.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::arch::x86_64::__cpuid;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
 
 use crate::arch::layout::{BIOS_DATA_END, EBDA_END, EBDA_START, MEM_64_START, RAM_32_SIZE};
-use crate::board::{Board, Result};
+use crate::board::{Board, BoardConfig, Result};
 use crate::hv::arch::Cpuid;
 use crate::hv::{Coco, Hypervisor, Vcpu, Vm};
 use crate::loader::InitState;
@@ -29,11 +30,21 @@ pub struct ArchBoard {
 }
 
 impl ArchBoard {
-    pub fn new<H: Hypervisor>(hv: &H) -> Result<Self> {
+    pub fn new<H: Hypervisor>(hv: &H, config: &BoardConfig) -> Result<Self> {
         let mut cpuids = hv.get_supported_cpuids()?;
         for cpuid in &mut cpuids {
             if cpuid.func == 0x1 {
                 cpuid.ecx |= (1 << 24) | (1 << 31);
+            } else if cpuid.func == 0x8000_001f {
+                // AMD Volume 3, section E.4.17.
+                if let Some(Coco::AmdSev { policy }) = &config.coco {
+                    cpuid.eax = if policy.es() { 0x2 | 0x8 } else { 0x2 };
+                    let host_ebx = unsafe { __cpuid(cpuid.func) }.ebx;
+                    // set PhysAddrReduction to 1
+                    cpuid.ebx = (1 << 6) | (host_ebx & 0x3f);
+                    cpuid.ecx = 0;
+                    cpuid.edx = 0;
+                }
             }
         }
         Ok(Self { cpuids })

--- a/alioth/src/hv/hv.rs
+++ b/alioth/src/hv/hv.rs
@@ -135,6 +135,13 @@ pub trait VmMemory: Debug + Send + Sync + 'static {
     fn unmap(&self, slot: u32, gpa: usize, size: usize) -> Result<(), Error>;
 
     fn max_mem_slots(&self) -> Result<u32, Error>;
+
+    fn register_encrypted_range(&self, _range: &[u8]) -> Result<()> {
+        unimplemented!()
+    }
+    fn deregister_encrypted_range(&self, _range: &[u8]) -> Result<()> {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -158,6 +165,22 @@ pub trait Vm {
     fn create_msi_sender(&self) -> Result<Self::MsiSender>;
     fn create_vm_memory(&mut self) -> Result<Self::Memory, Error>;
     fn stop_vcpu<T>(id: u32, handle: &JoinHandle<T>) -> Result<(), Error>;
+
+    fn sev_launch_start(&self, _policy: u32) -> Result<(), Error> {
+        unimplemented!()
+    }
+    fn sev_launch_update_vmsa(&self) -> Result<(), Error> {
+        unimplemented!()
+    }
+    fn sev_launch_update_data(&self, _range: &mut [u8]) -> Result<(), Error> {
+        unimplemented!()
+    }
+    fn sev_launch_measure(&self) -> Result<Vec<u8>, Error> {
+        unimplemented!()
+    }
+    fn sev_launch_finish(&self) -> Result<(), Error> {
+        unimplemented!()
+    }
 }
 
 pub trait Hypervisor {

--- a/alioth/src/hv/kvm/bindings.rs
+++ b/alioth/src/hv/kvm/bindings.rs
@@ -238,3 +238,10 @@ pub struct KvmIoEventFd {
     pub flags: KvmIoEventFdFlag,
     pub pad: [u32; 9],
 }
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmEncRegion {
+    pub addr: u64,
+    pub size: u64,
+}

--- a/alioth/src/hv/kvm/ioctls.rs
+++ b/alioth/src/hv/kvm/ioctls.rs
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 use crate::hv::kvm::bindings::{
-    KvmCpuid2, KvmIrqfd, KvmMsi, KvmRegs, KvmSregs2, KvmUserspaceMemoryRegion, KVMIO,
+    KvmCpuid2, KvmEncRegion, KvmIrqfd, KvmMsi, KvmRegs, KvmSregs2, KvmUserspaceMemoryRegion, KVMIO,
 };
-use crate::utils::ioctls::ioctl_io;
+use crate::utils::ioctls::{ioctl_io, ioctl_ior, ioctl_iowr};
 use crate::{
-    ioctl_none, ioctl_read, ioctl_write_buf, ioctl_write_ptr, ioctl_write_val, ioctl_writeread_buf,
+    ioctl_none, ioctl_read, ioctl_write_buf, ioctl_write_ptr, ioctl_write_val, ioctl_writeread,
+    ioctl_writeread_buf,
 };
 
 ioctl_none!(kvm_get_api_version, KVMIO, 0x00, 0);
@@ -51,6 +52,20 @@ ioctl_write_ptr!(kvm_set_regs, KVMIO, 0x82, KvmRegs);
 ioctl_write_buf!(kvm_set_cpuid2, KVMIO, 0x90, KvmCpuid2);
 
 ioctl_write_ptr!(kvm_signal_msi, KVMIO, 0xa5, KvmMsi);
+
+ioctl_writeread!(kvm_memory_encrypt_op, ioctl_iowr::<u64>(KVMIO, 0xba));
+
+ioctl_write_ptr!(
+    kvm_memory_encrypt_reg_region,
+    ioctl_ior::<KvmEncRegion>(KVMIO, 0xbb),
+    KvmEncRegion
+);
+
+ioctl_write_ptr!(
+    kvm_memory_encrypt_unreg_region,
+    ioctl_ior::<KvmEncRegion>(KVMIO, 0xbc),
+    KvmEncRegion
+);
 
 #[cfg(target_arch = "x86_64")]
 ioctl_read!(kvm_get_sregs2, KVMIO, 0xcc, KvmSregs2);

--- a/alioth/src/hv/kvm/kvm.rs
+++ b/alioth/src/hv/kvm/kvm.rs
@@ -14,6 +14,8 @@
 
 mod bindings;
 mod ioctls;
+#[path = "sev/sev.rs"]
+mod sev;
 #[path = "vcpu/vcpu.rs"]
 mod vcpu;
 mod vm;

--- a/alioth/src/hv/kvm/sev/bindings.rs
+++ b/alioth/src/hv/kvm/sev/bindings.rs
@@ -1,0 +1,239 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(dead_code)]
+
+pub const SEV_RET_SUCCESS: u32 = 0;
+pub const SEV_RET_INVALID_PLATFORM_STATE: u32 = 1;
+pub const SEV_RET_INVALID_GUEST_STATE: u32 = 2;
+pub const SEV_RET_INAVLID_CONFIG: u32 = 3;
+pub const SEV_RET_INVALID_LEN: u32 = 4;
+pub const SEV_RET_ALREADY_OWNED: u32 = 5;
+pub const SEV_RET_INVALID_CERTIFICATE: u32 = 6;
+pub const SEV_RET_POLICY_FAILURE: u32 = 7;
+pub const SEV_RET_INACTIVE: u32 = 8;
+pub const SEV_RET_INVALID_ADDRESS: u32 = 9;
+pub const SEV_RET_BAD_SIGNATURE: u32 = 10;
+pub const SEV_RET_BAD_MEASUREMENT: u32 = 11;
+pub const SEV_RET_ASID_OWNED: u32 = 12;
+pub const SEV_RET_INVALID_ASID: u32 = 13;
+pub const SEV_RET_WBINVD_REQUIRED: u32 = 14;
+pub const SEV_RET_DFFLUSH_REQUIRED: u32 = 15;
+pub const SEV_RET_INVALID_GUEST: u32 = 16;
+pub const SEV_RET_INVALID_COMMAND: u32 = 17;
+pub const SEV_RET_ACTIVE: u32 = 18;
+pub const SEV_RET_HWSEV_RET_PLATFORM: u32 = 19;
+pub const SEV_RET_HWSEV_RET_UNSAFE: u32 = 20;
+pub const SEV_RET_UNSUPPORTED: u32 = 21;
+pub const SEV_RET_INVALID_PARAM: u32 = 22;
+pub const SEV_RET_RESOURCE_LIMIT: u32 = 23;
+pub const SEV_RET_SECURE_DATA_INVALID: u32 = 24;
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct SevUserDataStatus {
+    pub api_major: u8,
+    pub api_minor: u8,
+    pub state: u8,
+    pub flags: u32,
+    pub build: u8,
+    pub guest_count: u32,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct SevUserDataPekCsr {
+    pub address: u64,
+    pub length: u32,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct SevUserDataPekCertImport {
+    pub pek_cert_address: u64,
+    pub pek_cert_len: u32,
+    pub oca_cert_address: u64,
+    pub oca_cert_len: u32,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct SevUserDataPdhCertExport {
+    pub pdh_cert_address: u64,
+    pub pdh_cert_len: u32,
+    pub cert_chain_address: u64,
+    pub cert_chain_len: u32,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct SevUserDataGetId {
+    pub socket1: [u8; 64],
+    pub socket2: [u8; 64],
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct SevUserDataGetId2 {
+    pub address: u64,
+    pub length: u32,
+}
+
+#[repr(C, packed(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct SevIssueCmd {
+    pub cmd: u32,
+    pub data: u64,
+    pub error: u32,
+}
+
+pub const KVM_SEV_INIT: u32 = 0;
+pub const KVM_SEV_ES_INIT: u32 = 1;
+pub const KVM_SEV_LAUNCH_START: u32 = 2;
+pub const KVM_SEV_LAUNCH_UPDATE_DATA: u32 = 3;
+pub const KVM_SEV_LAUNCH_UPDATE_VMSA: u32 = 4;
+pub const KVM_SEV_LAUNCH_SECRET: u32 = 5;
+pub const KVM_SEV_LAUNCH_MEASURE: u32 = 6;
+pub const KVM_SEV_LAUNCH_FINISH: u32 = 7;
+pub const KVM_SEV_SEND_START: u32 = 8;
+pub const KVM_SEV_SEND_UPDATE_DATA: u32 = 9;
+pub const KVM_SEV_SEND_UPDATE_VMSA: u32 = 10;
+pub const KVM_SEV_SEND_FINISH: u32 = 11;
+pub const KVM_SEV_RECEIVE_START: u32 = 12;
+pub const KVM_SEV_RECEIVE_UPDATE_DATA: u32 = 13;
+pub const KVM_SEV_RECEIVE_UPDATE_VMSA: u32 = 14;
+pub const KVM_SEV_RECEIVE_FINISH: u32 = 15;
+pub const KVM_SEV_GUEST_STATUS: u32 = 16;
+pub const KVM_SEV_DBG_DECRYPT: u32 = 17;
+pub const KVM_SEV_DBG_ENCRYPT: u32 = 18;
+pub const KVM_SEV_CERT_EXPORT: u32 = 19;
+pub const KVM_SEV_GET_ATTESTATION_REPORT: u32 = 20;
+pub const KVM_SEV_SEND_CANCEL: u32 = 21;
+pub const KVM_SEV_NR_MAX: u32 = 22;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevCmd {
+    pub id: u32,
+    pub data: u64,
+    pub error: u32,
+    pub sev_fd: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct KvmSevLaunchStart {
+    pub handle: u32,
+    pub policy: u32,
+    pub dh_uaddr: u64,
+    pub dh_len: u32,
+    pub session_uaddr: u64,
+    pub session_len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevLaunchUpdateData {
+    pub uaddr: u64,
+    pub len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevLaunchSecret {
+    pub hdr_uaddr: u64,
+    pub hdr_len: u32,
+    pub guest_uaddr: u64,
+    pub guest_len: u32,
+    pub trans_uaddr: u64,
+    pub trans_len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevLaunchMeasure {
+    pub uaddr: u64,
+    pub len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevGuestStatus {
+    pub handle: u32,
+    pub policy: u32,
+    pub state: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevDbg {
+    pub src_uaddr: u64,
+    pub dst_uaddr: u64,
+    pub len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevAttestationReport {
+    pub mnonce: [u8; 16],
+    pub uaddr: u64,
+    pub len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevSendStart {
+    pub policy: u32,
+    pub pdh_cert_uaddr: u64,
+    pub pdh_cert_len: u32,
+    pub plat_certs_uaddr: u64,
+    pub plat_certs_len: u32,
+    pub amd_certs_uaddr: u64,
+    pub amd_certs_len: u32,
+    pub session_uaddr: u64,
+    pub session_len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevSendUpdateData {
+    pub hdr_uaddr: u64,
+    pub hdr_len: u32,
+    pub guest_uaddr: u64,
+    pub guest_len: u32,
+    pub trans_uaddr: u64,
+    pub trans_len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevReceiveStart {
+    pub handle: u32,
+    pub policy: u32,
+    pub pdh_uaddr: u64,
+    pub pdh_len: u32,
+    pub session_uaddr: u64,
+    pub session_len: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct KvmSevReceiveUpdateData {
+    pub hdr_uaddr: u64,
+    pub hdr_len: u32,
+    pub guest_uaddr: u64,
+    pub guest_len: u32,
+    pub trans_uaddr: u64,
+    pub trans_len: u32,
+}

--- a/alioth/src/hv/kvm/sev/sev.rs
+++ b/alioth/src/hv/kvm/sev/sev.rs
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod layout;
-pub mod msr;
-pub mod paging;
-pub mod reg;
-pub mod sev;
+#![allow(dead_code)]
+
+pub mod bindings;
+
+use crate::ioctl_writeread;
+
+use bindings::SevIssueCmd;
+
+const SEV_IOC_TYPE: u8 = b'S';
+
+ioctl_writeread!(sev_issue_cmd, SEV_IOC_TYPE, 0x0, SevIssueCmd);

--- a/alioth/src/hv/kvm/vcpu/vcpu.rs
+++ b/alioth/src/hv/kvm/vcpu/vcpu.rs
@@ -186,8 +186,11 @@ mod test {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_vcpu_regs() {
+        use crate::hv::VmConfig;
+
         let kvm = Kvm::new().unwrap();
-        let vm = kvm.create_vm().unwrap();
+        let vm_config = VmConfig { coco: None };
+        let vm = kvm.create_vm(&vm_config).unwrap();
         let mut vcpu = vm.create_vcpu(0).unwrap();
         let regs = [
             (Reg::Rax, 0xa93f90f6ce9c8040),
@@ -330,8 +333,11 @@ mod test {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_kvm_run() {
+        use crate::hv::VmConfig;
+
         let kvm = Kvm::new().unwrap();
-        let mut vm = kvm.create_vm().unwrap();
+        let vm_config = VmConfig { coco: None };
+        let mut vm = kvm.create_vm(&vm_config).unwrap();
         let memory = vm.create_vm_memory().unwrap();
 
         let prot = PROT_WRITE | PROT_EXEC | PROT_READ;

--- a/alioth/src/loader/firmware/x86_64.rs
+++ b/alioth/src/loader/firmware/x86_64.rs
@@ -23,7 +23,7 @@ use crate::loader::{InitState, Result};
 use crate::mem::mapped::ArcMemPages;
 use crate::mem::{AddrOpt, MemRegion, MemRegionType, Memory};
 
-pub fn load<P: AsRef<Path>>(memory: &Memory, path: P) -> Result<InitState> {
+pub fn load<P: AsRef<Path>>(memory: &Memory, path: P) -> Result<(InitState, ArcMemPages)> {
     let file = File::open(path)?;
     let size = file.metadata()?.len() as usize;
     assert_eq!(size & 0xfff, 0);
@@ -32,7 +32,7 @@ pub fn load<P: AsRef<Path>>(memory: &Memory, path: P) -> Result<InitState> {
     let gpa = MEM_64_START - size;
     memory.add_region(
         AddrOpt::Fixed(gpa),
-        Arc::new(MemRegion::with_mapped(rom, MemRegionType::Reserved)),
+        Arc::new(MemRegion::with_mapped(rom.clone(), MemRegionType::Reserved)),
     )?;
     let boot_cs = SegRegVal {
         selector: 0xf000,
@@ -121,5 +121,5 @@ pub fn load<P: AsRef<Path>>(memory: &Memory, path: P) -> Result<InitState> {
         ],
         initramfs: None,
     };
-    Ok(init)
+    Ok((init, rom))
 }

--- a/alioth/src/mem/mapped.rs
+++ b/alioth/src/mem/mapped.rs
@@ -161,6 +161,14 @@ impl ArcMemPages {
         }
     }
 
+    pub fn as_slice_mut(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.addr as *mut u8, self.size) }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.addr as *const u8, self.size) }
+    }
+
     /// Given offset and len, return a slice, len might be truncated.
     fn get_partial_slice(&self, offset: usize, len: usize) -> Result<&[u8], Error> {
         let (addr, len) = self.get_valid_range(offset, len)?;
@@ -526,6 +534,17 @@ impl RamBus {
             }
         }
         Ok(callback(&mut iov))
+    }
+
+    pub fn register_encrypted_pages(&self, pages: &ArcMemPages) -> Result<()> {
+        self.vm_memory.register_encrypted_range(pages.as_slice())?;
+        Ok(())
+    }
+
+    pub fn deregister_encrypted_pages(&self, pages: &ArcMemPages) -> Result<()> {
+        self.vm_memory
+            .deregister_encrypted_range(pages.as_slice())?;
+        Ok(())
     }
 }
 

--- a/alioth/src/utils/ioctls.rs
+++ b/alioth/src/utils/ioctls.rs
@@ -134,6 +134,14 @@ macro_rules! ioctl_writeread {
             ))
         }
     };
+    ($name:ident, $code:expr) => {
+        pub unsafe fn $name<F: ::std::os::fd::AsRawFd, T>(
+            fd: &F,
+            val: &mut T,
+        ) -> ::std::io::Result<libc::c_int> {
+            $crate::ffi!(::libc::ioctl(fd.as_raw_fd(), $code as _, val as *mut T))
+        }
+    };
 }
 
 #[macro_export]

--- a/alioth/src/virtio/virtio.rs
+++ b/alioth/src/virtio/virtio.rs
@@ -51,8 +51,9 @@ bitflags! {
         const INDIRECT_DESC = 1 << 28;
         const EVENT_IDX = 1 << 29;
         const VERSION_1 = 1 << 32;
+        const ACCESS_PLATFORM = 1 << 33;
         const RING_PACKED = 1 << 34;
-        const SUPPORTED = Self::VERSION_1.bits();
+        const SUPPORTED = Self::VERSION_1.bits() | Self::ACCESS_PLATFORM.bits();
     }
 }
 

--- a/alioth/src/vm.rs
+++ b/alioth/src/vm.rs
@@ -86,7 +86,7 @@ where
         let mut vm = hv.create_vm(&vm_config)?;
         let vm_memory = vm.create_vm_memory()?;
         let memory = Memory::new(vm_memory);
-        let arch = ArchBoard::new(&hv)?;
+        let arch = ArchBoard::new(&hv, &config)?;
 
         let board = Board {
             vm,

--- a/alioth/src/vm.rs
+++ b/alioth/src/vm.rs
@@ -80,7 +80,9 @@ where
     H: Hypervisor + 'static,
 {
     pub fn new(hv: H, config: BoardConfig) -> Result<Self, Error> {
-        let vm_config = VmConfig { coco: None };
+        let vm_config = VmConfig {
+            coco: config.coco.clone(),
+        };
         let mut vm = hv.create_vm(&vm_config)?;
         let vm_memory = vm.create_vm_memory()?;
         let memory = Memory::new(vm_memory);

--- a/alioth/src/vm.rs
+++ b/alioth/src/vm.rs
@@ -25,7 +25,7 @@ use crate::board::{self, ArchBoard, Board, BoardConfig, STATE_CREATED, STATE_RUN
 use crate::device::fw_cfg::{FwCfg, FwCfgItemParam, PORT_SELECTOR};
 use crate::device::pvpanic::PvPanic;
 use crate::device::serial::Serial;
-use crate::hv::{self, Hypervisor, Vm};
+use crate::hv::{self, Hypervisor, Vm, VmConfig};
 use crate::loader::{self, Payload};
 use crate::mem::Memory;
 use crate::pci::bus::PciBus;
@@ -80,7 +80,8 @@ where
     H: Hypervisor + 'static,
 {
     pub fn new(hv: H, config: BoardConfig) -> Result<Self, Error> {
-        let mut vm = hv.create_vm()?;
+        let vm_config = VmConfig { coco: None };
+        let mut vm = hv.create_vm(&vm_config)?;
         let vm_memory = vm.create_vm_memory()?;
         let memory = Memory::new(vm_memory);
         let arch = ArchBoard::new(&hv)?;

--- a/docs/coco.md
+++ b/docs/coco.md
@@ -1,0 +1,36 @@
+# Confidential Compute (coco)
+
+Alioth supports booting confidential guests on the following platforms:
+
+- AMD-SEV [^sev]
+
+## AMD-SEV guest with Oak/Stage0 firmware
+
+WARNING: the current implementation takes QEMU [^qemu] as a reference and should
+be used in testing environments only.
+
+To launch an SEV guest,
+
+1. build the stage0 firmware from the Oak project[^stage0],
+2. prepare the guest Linux kernel of ELF format, the initramfs, and the kernel
+   command line in a text file,
+3. for SEV guests, `POLICY=0x1`, for SEV-ES guests, `POLICY=0x5`,
+4. launch the guest by
+   ```bash
+   ./alioth run -f /path/to/oak_stage0.bin \
+       --mem-size 1G \
+       --num-cpu 2 \
+       --fw-cfg name=opt/stage0/elf_kernel,file=/path/to/elf_kernel \
+       --fw-cfg name=opt/stage0/initramfs,file=/path/to/initramfs \
+       --fw-cfg name=opt/stage0/cmdline,file=/path/to/cmdline.txt \
+       --coco sev,policy=$POLICY
+   ```
+
+[^sev]:
+    [AMD Secure Encrypted Virtualization (SEV)](https://www.amd.com/en/developer/sev.html)
+
+[^stage0]:
+    [Oak/stage0 firmware](https://github.com/project-oak/oak/tree/main/stage0_bin)
+
+[^qemu]:
+    [QEMU's doc on SEV](https://www.qemu.org/docs/master/system/i386/amd-memory-encryption.html)


### PR DESCRIPTION
# Confidential Compute (coco)

Alioth supports booting confidential guests on the following platforms:

- AMD-SEV [^sev]

## AMD-SEV guest with Oak/Stage0 firmware

WARNING: the current implementation takes QEMU [^qemu] as a reference and should
be used in testing environments only.

To launch an SEV guest,

1. build the stage0 firmware from the Oak project[^stage0],
2. prepare the guest Linux kernel of ELF format, the initramfs, and the kernel
   command line in a text file,
3. for SEV guests, `POLICY=0x1`, for SEV-ES guests, `POLICY=0x5`,
4. launch the guest by
   ```bash
   ./alioth run -f /path/to/oak_stage0.bin \
       --mem-size 1G \
       --num-cpu 2 \
       --fw-cfg name=opt/stage0/elf_kernel,file=/path/to/elf_kernel \
       --fw-cfg name=opt/stage0/initramfs,file=/path/to/initramfs \
       --fw-cfg name=opt/stage0/cmdline,file=/path/to/cmdline.txt \
       --coco sev,policy=$POLICY
   ```

[^sev]:
    [AMD Secure Encrypted Virtualization (SEV)](https://www.amd.com/en/developer/sev.html)

[^stage0]:
    [Oak/stage0 firmware](https://github.com/project-oak/oak/tree/main/stage0_bin)

[^qemu]:
    [QEMU's doc on SEV](https://www.qemu.org/docs/master/system/i386/amd-memory-encryption.html)
