### PR TITLE
perf(virtio)!: use KVM_IOEVENTFD for queue notify

### DIFF
--- a/alioth/src/hv/kvm/ioctls.rs
+++ b/alioth/src/hv/kvm/ioctls.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::hv::kvm::bindings::{
-    KvmCpuid2, KvmEncRegion, KvmIrqfd, KvmMsi, KvmRegs, KvmSregs, KvmSregs2,
+    KvmCpuid2, KvmEncRegion, KvmIoEventFd, KvmIrqfd, KvmMsi, KvmRegs, KvmSregs, KvmSregs2,
     KvmUserspaceMemoryRegion, KVMIO,
 };
 use crate::utils::ioctls::{ioctl_io, ioctl_ior, ioctl_iowr};
@@ -44,6 +44,7 @@ ioctl_write_ptr!(kvm_set_identity_map_addr, KVMIO, 0x48, u64);
 ioctl_none!(kvm_create_irqchip, KVMIO, 0x60, 0);
 
 ioctl_write_ptr!(kvm_irqfd, KVMIO, 0x76, KvmIrqfd);
+ioctl_write_ptr!(kvm_ioeventfd, KVMIO, 0x79, KvmIoEventFd);
 
 ioctl_none!(kvm_run, KVMIO, 0x80, 0);
 ioctl_read!(kvm_get_regs, KVMIO, 0x81, KvmRegs);

--- a/alioth/src/hv/kvm/kvm.rs
+++ b/alioth/src/hv/kvm/kvm.rs
@@ -22,6 +22,7 @@ mod vm;
 mod vmentry;
 mod vmexit;
 
+use std::collections::HashMap;
 use std::fs::File;
 use std::mem::{size_of, transmute};
 use std::os::fd::{FromRawFd, OwnedFd};
@@ -35,6 +36,7 @@ use crate::hv::Cpuid;
 use crate::hv::{Error, Hypervisor};
 use bindings::{KvmCpuid2, KvmCpuid2Flag, KvmCpuidEntry2, KVM_API_VERSION, KVM_MAX_CPUID_ENTRIES};
 use ioctls::{kvm_create_irqchip, kvm_create_vm, kvm_get_api_version, kvm_get_vcpu_mmap_size};
+use parking_lot::Mutex;
 use serde::Deserialize;
 
 use crate::hv::{Coco, VmConfig};
@@ -105,6 +107,7 @@ impl Hypervisor for Kvm {
             sev_fd,
             vcpu_mmap_size,
             memory_created: false,
+            ioeventfds: Arc::new(Mutex::new(HashMap::new())),
         };
         if kvm_vm.sev_fd.is_some() {
             match config.coco.as_ref().unwrap() {

--- a/alioth/src/mem/mem.rs
+++ b/alioth/src/mem/mem.rs
@@ -67,8 +67,6 @@ pub enum Error {
     LockPoisoned,
     #[error("cannot allocate")]
     CanotAllocate,
-    #[error("cannot register MMIO notifier: {0}")]
-    Notifier(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("{0}")]
     Hv(#[from] hv::Error),
     #[error("cannot handle action: {0:x?}")]

--- a/alioth/src/virtio/virtio.rs
+++ b/alioth/src/virtio/virtio.rs
@@ -17,7 +17,7 @@ use std::fmt::Debug;
 use bitflags::bitflags;
 use thiserror::Error;
 
-use crate::mem;
+use crate::{hv, mem};
 
 #[path = "dev/dev.rs"]
 pub mod dev;
@@ -28,7 +28,7 @@ pub mod queue;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("hypervisor: {0}")]
-    Hv(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    Hv(#[from] hv::Error),
 
     #[error("IO: {0}")]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
KVM_IOEVENTFD avoids the VM exits of VCPU threads from kernel space
to user space.

Further we use a non-zero notify_off_multiplier [^1] in virtio device
configs. By just looking at the MMIO address we are able to tell
which queue is sending the notification. The value written to the
MMIO address is not needed. Thus the instruction decoding in the KVM
is avoided.

Test setup:

- Host CPU: AMD Ryzen 9 5950X
- VM: memory size 1G, 1 VCPU

virtio-net thought put by iperf3:

- VM -> host
  - without KVM_IOEVENTFD: 30.6 Gbits/sec
  - with KVM_IOEVENTFD: 33.5 Gbits/sec

- Host -> VM
  - without KVM_IOEVENTFD: 19.5 Gbits/sec
  - with KVM_IOEVENTFD: 25.4 Gbits/sec

[^1]: Virtio Spec 1.2, Sec 4.1.4.4.
