### PR TITLE
fix(virtio): devices return the full feature sets

### DIFF
--- a/alioth/src/virtio/dev/blk.rs
+++ b/alioth/src/virtio/dev/blk.rs
@@ -28,7 +28,7 @@ use crate::mem::mapped::RamBus;
 use crate::virtio::dev::{DevParam, Virtio};
 use crate::virtio::queue::handlers::handle_desc;
 use crate::virtio::queue::{Descriptor, VirtQueue};
-use crate::virtio::{DeviceId, IrqSender, Result};
+use crate::virtio::{DeviceId, IrqSender, Result, FEATURE_BUILT_IN};
 
 pub const VIRTIO_BLK_T_IN: u32 = 0;
 pub const VIRTIO_BLK_T_OUT: u32 = 1;
@@ -260,7 +260,7 @@ impl Virtio for Block {
     }
 
     fn feature(&self) -> u64 {
-        self.feature.bits()
+        self.feature.bits() | FEATURE_BUILT_IN
     }
 
     fn activate(&mut self, _registry: &Registry, _feature: u64, _memory: &RamBus) -> Result<()> {

--- a/alioth/src/virtio/dev/blk.rs
+++ b/alioth/src/virtio/dev/blk.rs
@@ -244,6 +244,7 @@ impl Block {
 
 impl Virtio for Block {
     type Config = BlockConfig;
+    type Feature = BlockFeature;
 
     fn reset(&mut self, _registry: &Registry) {}
 

--- a/alioth/src/virtio/dev/dev.rs
+++ b/alioth/src/virtio/dev/dev.rs
@@ -159,7 +159,7 @@ where
         let poll = Poll::new()?;
         let device_config = dev.config();
         let reg = Arc::new(Register {
-            device_feature: dev.feature() | VirtioFeature::SUPPORTED.bits(),
+            device_feature: dev.feature(),
             ..Default::default()
         });
         let num_queues = dev.num_queues();

--- a/alioth/src/virtio/dev/entropy.rs
+++ b/alioth/src/virtio/dev/entropy.rs
@@ -28,7 +28,7 @@ use crate::mem::mapped::RamBus;
 use crate::virtio::dev::{DevParam, DeviceId, Virtio};
 use crate::virtio::queue::handlers::reader_to_queue;
 use crate::virtio::queue::VirtQueue;
-use crate::virtio::{IrqSender, Result};
+use crate::virtio::{IrqSender, Result, FEATURE_BUILT_IN};
 
 #[derive(Debug, Clone)]
 pub struct EntropyConfig;
@@ -109,7 +109,7 @@ impl Virtio for Entropy {
     }
 
     fn feature(&self) -> u64 {
-        0
+        FEATURE_BUILT_IN
     }
 
     fn activate(&mut self, _registry: &Registry, _feature: u64, _memory: &RamBus) -> Result<()> {

--- a/alioth/src/virtio/dev/entropy.rs
+++ b/alioth/src/virtio/dev/entropy.rs
@@ -18,6 +18,7 @@ use std::mem::size_of;
 use std::os::unix::prelude::OpenOptionsExt;
 use std::sync::Arc;
 
+use bitflags::bitflags;
 use libc::O_NONBLOCK;
 use mio::event::Event;
 use mio::Registry;
@@ -47,6 +48,11 @@ impl Mmio for EntropyConfig {
     }
 }
 
+bitflags! {
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct EntropyFeature: u64 { }
+}
+
 #[derive(Debug)]
 pub struct Entropy {
     name: Arc<String>,
@@ -69,6 +75,7 @@ impl Entropy {
 
 impl Virtio for Entropy {
     type Config = EntropyConfig;
+    type Feature = EntropyFeature;
 
     fn num_queues(&self) -> u16 {
         1

--- a/alioth/src/virtio/dev/net/net.rs
+++ b/alioth/src/virtio/dev/net/net.rs
@@ -146,7 +146,6 @@ impl Net {
             | NetFeature::HOST_UFO
             | NetFeature::HOST_USO
             | detect_tap_offload(&file);
-        log::debug!("{name}: device fature: {dev_feat:x?}");
         setup_tap(&mut file, param.if_name.as_deref())?;
         let net = Net {
             name,
@@ -165,6 +164,7 @@ impl Net {
 
 impl Virtio for Net {
     type Config = NetConfig;
+    type Feature = NetFeature;
 
     fn num_queues(&self) -> u16 {
         let data_queues = self.config.max_queue_pairs << 1;
@@ -193,7 +193,6 @@ impl Virtio for Net {
 
     fn activate(&mut self, registry: &Registry, feature: u64, _memory: &RamBus) -> Result<()> {
         let feature = NetFeature::from_bits_retain(feature);
-        log::debug!("{}: driver feature: {:?}", self.name, feature);
         enable_tap_offload(&mut self.tap, feature)?;
         registry.register(
             &mut SourceFd(&self.tap.as_raw_fd()),

--- a/alioth/src/virtio/dev/net/net.rs
+++ b/alioth/src/virtio/dev/net/net.rs
@@ -37,7 +37,7 @@ use crate::net::MacAddr;
 use crate::virtio::dev::{DevParam, DeviceId, Result, Virtio};
 use crate::virtio::queue::handlers::{queue_to_writer, reader_to_queue};
 use crate::virtio::queue::VirtQueue;
-use crate::virtio::{IrqSender, VirtioFeature};
+use crate::virtio::{IrqSender, FEATURE_BUILT_IN};
 
 pub mod tap;
 
@@ -188,7 +188,7 @@ impl Virtio for Net {
     }
 
     fn feature(&self) -> u64 {
-        self.feature.bits() | VirtioFeature::EVENT_IDX.bits()
+        self.feature.bits() | FEATURE_BUILT_IN
     }
 
     fn activate(&mut self, registry: &Registry, feature: u64, _memory: &RamBus) -> Result<()> {

--- a/alioth/src/virtio/virtio.rs
+++ b/alioth/src/virtio/virtio.rs
@@ -53,9 +53,12 @@ bitflags! {
         const VERSION_1 = 1 << 32;
         const ACCESS_PLATFORM = 1 << 33;
         const RING_PACKED = 1 << 34;
-        const SUPPORTED = Self::VERSION_1.bits() | Self::ACCESS_PLATFORM.bits();
     }
 }
+
+const FEATURE_BUILT_IN: u64 = VirtioFeature::EVENT_IDX.bits()
+    | VirtioFeature::VERSION_1.bits()
+    | VirtioFeature::ACCESS_PLATFORM.bits();
 
 #[derive(Debug, Clone, Copy)]
 pub enum DeviceId {


### PR DESCRIPTION
Previously, each device only returns the device specific features and VirtioDevice::new() adds the general virtio feature bits. This causes troubles for supporting vhost-user backends, which may implement a different set of general virtio feature bits.

This commit lets individual devices return the full feature sets. The general virtio feature bits implemented by the module virtio is moved to `FEATURE_BUILT_IN`, which implicitly turns on the `EVENT_IDX` for the entropy and block device.
