### PR TITLE
Support vhost-user virtio-fs with virtiofsd as the backend

### DIFF
--- a/alioth/src/board/board.rs
+++ b/alioth/src/board/board.rs
@@ -324,6 +324,9 @@ where
             }
 
             if id == 0 {
+                for dev in self.pci_devs.read().iter() {
+                    dev.dev.reset()?;
+                }
                 self.memory.reset()?;
             }
         }

--- a/alioth/src/board/x86_64.rs
+++ b/alioth/src/board/x86_64.rs
@@ -132,7 +132,7 @@ where
         let memory = &self.memory;
 
         let low_mem_size = std::cmp::min(config.mem_size, RAM_32_SIZE);
-        let pages_low = ArcMemPages::new_anon(low_mem_size)?;
+        let pages_low = ArcMemPages::from_anonymous(low_mem_size, None, Some(c"ram-low"))?;
         if self.config.coco.is_some() {
             self.memory.ram_bus().register_encrypted_pages(&pages_low)?;
         }
@@ -161,7 +161,11 @@ where
         };
         memory.add_region(AddrOpt::Fixed(0), Arc::new(region_low))?;
         if config.mem_size > RAM_32_SIZE {
-            let mem_hi = ArcMemPages::new_anon(config.mem_size - RAM_32_SIZE)?;
+            let mem_hi = ArcMemPages::from_anonymous(
+                config.mem_size - RAM_32_SIZE,
+                None,
+                Some(c"ram-high"),
+            )?;
             if self.config.coco.is_some() {
                 self.memory.ram_bus().register_encrypted_pages(&mem_hi)?;
             }

--- a/alioth/src/hv/hv.rs
+++ b/alioth/src/hv/hv.rs
@@ -54,6 +54,8 @@ pub enum Error {
     LackCap { cap: String },
     #[error("creating multipe memory")]
     CreatingMultipleMemory,
+    #[error("cannot allocate irqfd")]
+    CannotAllocateIrqFd,
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -120,7 +122,9 @@ where
 }
 
 pub trait MsiSender: Debug + Send + Sync + 'static {
+    type IrqFd: IrqFd;
     fn send(&self, addr: u64, data: u32) -> Result<()>;
+    fn create_irqfd(&self) -> Result<Self::IrqFd>;
 }
 
 pub trait VmMemory: Debug + Send + Sync + 'static {
@@ -160,6 +164,17 @@ pub trait IoeventFdRegistry: Debug + Send + Sync + 'static {
         data: Option<u64>,
     ) -> Result<()>;
     fn deregister(&self, fd: &Self::IoeventFd) -> Result<()>;
+}
+
+pub trait IrqFd: Debug + Send + Sync + AsFd + 'static {
+    fn set_addr_lo(&self, val: u32) -> Result<()>;
+    fn get_addr_lo(&self) -> u32;
+    fn set_addr_hi(&self, val: u32) -> Result<()>;
+    fn get_addr_hi(&self) -> u32;
+    fn set_data(&self, val: u32) -> Result<()>;
+    fn get_data(&self) -> u32;
+    fn set_masked(&self, val: bool) -> Result<()>;
+    fn get_masked(&self) -> bool;
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/alioth/src/hv/kvm/ioctls.rs
+++ b/alioth/src/hv/kvm/ioctls.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::hv::kvm::bindings::{
-    KvmCpuid2, KvmEncRegion, KvmIoEventFd, KvmIrqfd, KvmMsi, KvmRegs, KvmSregs, KvmSregs2,
-    KvmUserspaceMemoryRegion, KVMIO,
+    KvmCpuid2, KvmEncRegion, KvmIoEventFd, KvmIrqRouting, KvmIrqfd, KvmMsi, KvmRegs, KvmSregs,
+    KvmSregs2, KvmUserspaceMemoryRegion, KVMIO,
 };
 use crate::utils::ioctls::{ioctl_io, ioctl_ior, ioctl_iowr};
 use crate::{
@@ -42,6 +42,7 @@ ioctl_write_val!(kvm_set_tss_addr, ioctl_io(KVMIO, 0x47));
 ioctl_write_ptr!(kvm_set_identity_map_addr, KVMIO, 0x48, u64);
 
 ioctl_none!(kvm_create_irqchip, KVMIO, 0x60, 0);
+ioctl_write_buf!(kvm_set_gsi_routing, KVMIO, 0x6a, KvmIrqRouting);
 
 ioctl_write_ptr!(kvm_irqfd, KVMIO, 0x76, KvmIrqfd);
 ioctl_write_ptr!(kvm_ioeventfd, KVMIO, 0x79, KvmIoEventFd);

--- a/alioth/src/loader/firmware/x86_64.rs
+++ b/alioth/src/loader/firmware/x86_64.rs
@@ -29,7 +29,7 @@ pub fn load<P: AsRef<Path>>(memory: &Memory, path: P) -> Result<(InitState, ArcM
     let size = file.metadata()?.len() as usize;
     assert_eq!(size & 0xfff, 0);
 
-    let mut rom = ArcMemPages::new_anon(size)?;
+    let mut rom = ArcMemPages::from_anonymous(size, None, Some(c"rom"))?;
     file.read_exact(rom.as_slice_mut())?;
 
     let gpa = MEM_64_START - size;

--- a/alioth/src/mem/mapped.rs
+++ b/alioth/src/mem/mapped.rs
@@ -360,6 +360,11 @@ impl Addressable<MappedSlot> {
         }
     }
 
+    pub fn translate(&self, gpa: usize) -> Result<*const u8> {
+        let s = self.get_partial_slice(gpa, 1)?;
+        Ok(s.as_ptr())
+    }
+
     pub fn translate_iov<'a>(&'a self, iov: &[(usize, usize)]) -> Result<Vec<IoSlice<'a>>> {
         let mut slices = vec![];
         for (gpa, len) in iov {

--- a/alioth/src/virtio/dev/blk.rs
+++ b/alioth/src/virtio/dev/blk.rs
@@ -27,7 +27,7 @@ use crate::impl_mmio_for_zerocopy;
 use crate::mem::mapped::RamBus;
 use crate::virtio::dev::{DevParam, Virtio};
 use crate::virtio::queue::handlers::handle_desc;
-use crate::virtio::queue::{Descriptor, VirtQueue};
+use crate::virtio::queue::{Descriptor, Queue, VirtQueue};
 use crate::virtio::{DeviceId, IrqSender, Result, FEATURE_BUILT_IN};
 
 pub const VIRTIO_BLK_T_IN: u32 = 0;
@@ -264,7 +264,14 @@ impl Virtio for Block {
         self.feature.bits() | FEATURE_BUILT_IN
     }
 
-    fn activate(&mut self, _registry: &Registry, _feature: u64, _memory: &RamBus) -> Result<()> {
+    fn activate(
+        &mut self,
+        _registry: &Registry,
+        _feature: u64,
+        _memory: &RamBus,
+        _irq_sender: &impl IrqSender,
+        _queues: &[Queue],
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/alioth/src/virtio/dev/entropy.rs
+++ b/alioth/src/virtio/dev/entropy.rs
@@ -28,7 +28,7 @@ use crate::mem::emulated::Mmio;
 use crate::mem::mapped::RamBus;
 use crate::virtio::dev::{DevParam, DeviceId, Virtio};
 use crate::virtio::queue::handlers::reader_to_queue;
-use crate::virtio::queue::VirtQueue;
+use crate::virtio::queue::{Queue, VirtQueue};
 use crate::virtio::{IrqSender, Result, FEATURE_BUILT_IN};
 
 #[derive(Debug, Clone)]
@@ -119,7 +119,14 @@ impl Virtio for Entropy {
         FEATURE_BUILT_IN
     }
 
-    fn activate(&mut self, _registry: &Registry, _feature: u64, _memory: &RamBus) -> Result<()> {
+    fn activate(
+        &mut self,
+        _registry: &Registry,
+        _feature: u64,
+        _memory: &RamBus,
+        _irq_sender: &impl IrqSender,
+        _queues: &[Queue],
+    ) -> Result<()> {
         Ok(())
     }
 }

--- a/alioth/src/virtio/dev/fs.rs
+++ b/alioth/src/virtio/dev/fs.rs
@@ -1,0 +1,288 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::mem::size_of_val;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use bitflags::bitflags;
+use libc::{eventfd, EFD_CLOEXEC, EFD_NONBLOCK};
+use mio::event::Event;
+use mio::unix::SourceFd;
+use mio::{Interest, Registry, Token};
+use serde::Deserialize;
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
+use crate::hv::IoeventFd;
+use crate::mem::mapped::RamBus;
+use crate::virtio::dev::{DevParam, Virtio};
+use crate::virtio::queue::{Queue, VirtQueue};
+use crate::virtio::vu::{
+    DeviceConfig, MemoryRegion, MemorySingleRegion, VirtqAddr, VirtqState, VuDev, VuFeature,
+};
+use crate::virtio::{DeviceId, Error, IrqSender, Result, VirtioFeature};
+use crate::{ffi, impl_mmio_for_zerocopy};
+
+#[repr(C, align(4))]
+#[derive(Debug, FromBytes, FromZeroes, AsBytes)]
+pub struct FsConfig {
+    tag: [u8; 36],
+    num_request_queues: u32,
+    notify_buf_size: u32,
+}
+
+impl_mmio_for_zerocopy!(FsConfig);
+
+bitflags! {
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct FsFeature: u64 {
+        const NOTIFICATION = 1 << 0;
+    }
+}
+
+#[derive(Debug)]
+pub struct VuFs {
+    name: Arc<String>,
+    vu_dev: VuDev,
+    config: Arc<FsConfig>,
+    feature: u64,
+    num_queues: u16,
+    regions: Vec<MemoryRegion>,
+    error_fds: Vec<OwnedFd>,
+}
+
+impl VuFs {
+    pub fn new(param: VuFsParam, name: Arc<String>) -> Result<Self> {
+        let vu_dev = VuDev::new(param.socket)?;
+        let dev_feat = vu_dev.get_features()?;
+        let virtio_feat = VirtioFeature::from_bits_retain(dev_feat);
+        let need_feat = VirtioFeature::VHOST_PROTOCOL | VirtioFeature::VERSION_1;
+        if !virtio_feat.contains(need_feat) {
+            return Err(Error::VuMissingDeviceFeature(need_feat.bits()));
+        }
+
+        let prot_feat = VuFeature::from_bits_retain(vu_dev.get_protocol_features()?);
+        log::debug!("{name}: vhost-user feat: {prot_feat:x?}");
+        let mut need_feat = VuFeature::MQ | VuFeature::REPLY_ACK | VuFeature::CONFIGURE_MEM_SLOTS;
+        if param.tag.is_none() {
+            need_feat |= VuFeature::CONFIG;
+        }
+        if !prot_feat.contains(need_feat) {
+            return Err(Error::VuMissingProtocolFeature(need_feat & !prot_feat));
+        }
+        vu_dev.set_protocol_features(&need_feat.bits())?;
+
+        vu_dev.set_owner()?;
+        let num_queues = vu_dev.get_queue_num()? as u16;
+        let config = if let Some(tag) = param.tag {
+            assert!(tag.len() <= 36);
+            assert_ne!(tag.len(), 0);
+            let mut config = FsConfig::new_zeroed();
+            config.tag[0..tag.len()].copy_from_slice(tag.as_bytes());
+            config.num_request_queues = num_queues as u32 - 1;
+            if FsFeature::from_bits_retain(dev_feat).contains(FsFeature::NOTIFICATION) {
+                config.num_request_queues -= 1;
+            }
+            config
+        } else {
+            let mut empty_cfg = DeviceConfig::new_zeroed();
+            empty_cfg.size = size_of_val(&empty_cfg.region) as _;
+            let dev_config = vu_dev.get_config(&empty_cfg)?;
+            FsConfig::read_from_prefix(&dev_config.region).unwrap()
+        };
+
+        Ok(VuFs {
+            num_queues,
+            name,
+            vu_dev,
+            config: Arc::new(config),
+            feature: dev_feat & !VirtioFeature::VHOST_PROTOCOL.bits(),
+            regions: Vec::new(),
+            error_fds: Vec::new(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VuFsParam {
+    pub socket: PathBuf,
+    pub tag: Option<String>,
+}
+
+impl DevParam for VuFsParam {
+    type Device = VuFs;
+
+    fn build(self, name: Arc<String>) -> Result<Self::Device> {
+        VuFs::new(self, name)
+    }
+}
+
+impl Virtio for VuFs {
+    type Config = FsConfig;
+    type Feature = FsFeature;
+
+    fn config(&self) -> Arc<Self::Config> {
+        self.config.clone()
+    }
+    fn device_id() -> DeviceId {
+        DeviceId::FileSystem
+    }
+    fn feature(&self) -> u64 {
+        self.feature
+    }
+
+    fn activate(
+        &mut self,
+        registry: &Registry,
+        feature: u64,
+        memory: &RamBus,
+        irq_sender: &impl IrqSender,
+        queues: &[Queue],
+    ) -> Result<()> {
+        self.vu_dev
+            .set_features(&(feature | VirtioFeature::VHOST_PROTOCOL.bits()))?;
+        let mem = memory.lock_layout();
+        for (gpa, slot) in mem.iter() {
+            let region = MemorySingleRegion {
+                _padding: 0,
+                region: MemoryRegion {
+                    gpa: gpa as _,
+                    size: slot.pages.size() as _,
+                    hva: slot.pages.addr() as _,
+                    mmap_offset: 0,
+                },
+            };
+            self.vu_dev
+                .add_mem_region(&region, slot.pages.fd().as_raw_fd())
+                .unwrap();
+            log::info!("region: {region:x?}");
+            self.regions.push(region.region);
+        }
+        for (index, queue) in queues.iter().enumerate() {
+            let irq_fd = irq_sender.queue_irqfd(index as _)?;
+            self.vu_dev.set_virtq_call(&(index as u64), irq_fd).unwrap();
+
+            let err_fd =
+                unsafe { OwnedFd::from_raw_fd(ffi!(eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK))?) };
+            self.vu_dev
+                .set_virtq_err(&(index as u64), err_fd.as_raw_fd())
+                .unwrap();
+            registry.register(
+                &mut SourceFd(&err_fd.as_raw_fd()),
+                Token(index),
+                Interest::READABLE,
+            )?;
+            self.error_fds.push(err_fd);
+
+            let virtq_num = VirtqState {
+                index: index as _,
+                val: queue.size.load(Ordering::Acquire) as _,
+            };
+            self.vu_dev.set_virtq_num(&virtq_num).unwrap();
+            log::info!("set_virtq_num: {virtq_num:x?}");
+
+            let virtq_base = VirtqState {
+                index: index as _,
+                val: 0,
+            };
+            self.vu_dev.set_virtq_base(&virtq_base).unwrap();
+
+            log::info!("set_virtq_base: {virtq_base:x?}");
+            let virtq_addr = VirtqAddr {
+                index: index as _,
+                flags: 0,
+                desc_hva: mem.translate(queue.desc.load(Ordering::Acquire) as _)? as _,
+                used_hva: mem.translate(queue.device.load(Ordering::Acquire) as _)? as _,
+                avail_hva: mem.translate(queue.driver.load(Ordering::Acquire) as _)? as _,
+                log_guest_addr: 0,
+            };
+            self.vu_dev.set_virtq_addr(&virtq_addr).unwrap();
+            log::info!("queue: {:x?}", queue);
+            log::info!("virtq_addr: {virtq_addr:x?}");
+        }
+        for index in 0..queues.len() {
+            let virtq_enable = VirtqState {
+                index: index as _,
+                val: 1,
+            };
+            self.vu_dev.set_virtq_enable(&virtq_enable).unwrap();
+            log::info!("virtq_enable: {virtq_enable:x?}");
+        }
+        Ok(())
+    }
+
+    fn handle_event(
+        &mut self,
+        event: &Event,
+        _queues: &[impl VirtQueue],
+        _irq_sender: &impl IrqSender,
+        _registry: &Registry,
+    ) -> Result<()> {
+        let q_index = event.token();
+        Err(Error::VuQueueErr(q_index.0 as _))
+    }
+
+    fn handle_queue(
+        &mut self,
+        index: u16,
+        _queues: &[impl VirtQueue],
+        _irq_sender: &impl IrqSender,
+        _registry: &Registry,
+    ) -> Result<()> {
+        unreachable!(
+            "{}: queue {index} notification should go to vhost-user backend",
+            self.name
+        )
+    }
+
+    fn num_queues(&self) -> u16 {
+        self.num_queues
+    }
+
+    fn reset(&mut self, registry: &Registry) {
+        for q_index in 0..self.num_queues {
+            let disable = VirtqState {
+                index: q_index as _,
+                val: 0,
+            };
+            self.vu_dev.set_virtq_enable(&disable).unwrap();
+        }
+        while let Some(fd) = self.error_fds.pop() {
+            registry.deregister(&mut SourceFd(&fd.as_raw_fd())).unwrap();
+        }
+        while let Some(region) = self.regions.pop() {
+            self.vu_dev
+                .remove_mem_region(&MemorySingleRegion {
+                    _padding: 0,
+                    region,
+                })
+                .unwrap()
+        }
+    }
+
+    fn offload_ioeventfd<E>(&self, q_index: u16, fd: &E) -> Result<bool>
+    where
+        E: IoeventFd,
+    {
+        if q_index < self.num_queues {
+            self.vu_dev
+                .set_virtq_kick(&(q_index as u64), fd.as_fd().as_raw_fd())?;
+            Ok(true)
+        } else {
+            Err(Error::InvalidQueueIndex(q_index))
+        }
+    }
+}

--- a/alioth/src/virtio/dev/net/net.rs
+++ b/alioth/src/virtio/dev/net/net.rs
@@ -36,7 +36,7 @@ use crate::mem::mapped::RamBus;
 use crate::net::MacAddr;
 use crate::virtio::dev::{DevParam, DeviceId, Result, Virtio};
 use crate::virtio::queue::handlers::{queue_to_writer, reader_to_queue};
-use crate::virtio::queue::VirtQueue;
+use crate::virtio::queue::{Queue, VirtQueue};
 use crate::virtio::{IrqSender, FEATURE_BUILT_IN};
 
 pub mod tap;
@@ -191,7 +191,14 @@ impl Virtio for Net {
         self.feature.bits() | FEATURE_BUILT_IN
     }
 
-    fn activate(&mut self, registry: &Registry, feature: u64, _memory: &RamBus) -> Result<()> {
+    fn activate(
+        &mut self,
+        registry: &Registry,
+        feature: u64,
+        _memory: &RamBus,
+        _irq_sender: &impl IrqSender,
+        _queues: &[Queue],
+    ) -> Result<()> {
         let feature = NetFeature::from_bits_retain(feature);
         enable_tap_offload(&mut self.tap, feature)?;
         registry.register(

--- a/alioth/src/virtio/virtio.rs
+++ b/alioth/src/virtio/virtio.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::fmt::Debug;
+use std::os::fd::RawFd;
 
 use bitflags::bitflags;
 use thiserror::Error;
@@ -41,6 +42,12 @@ pub enum Error {
 
     #[error("Invalid descriptor id {0}")]
     InvalidDescriptor(u16),
+
+    #[error("invalid queue index {0}")]
+    InvalidQueueIndex(u16),
+
+    #[error("invalid msix vector {0}")]
+    InvalidMsixVector(u16),
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -87,4 +94,6 @@ bitflags! {
 pub trait IrqSender: Send + Sync + Debug + 'static {
     fn queue_irq(&self, idx: u16);
     fn config_irq(&self);
+    fn queue_irqfd(&self, idx: u16) -> Result<RawFd>;
+    fn config_irqfd(&self) -> Result<RawFd>;
 }

--- a/alioth/src/virtio/virtio.rs
+++ b/alioth/src/virtio/virtio.rs
@@ -64,6 +64,12 @@ pub enum Error {
 
     #[error("vhost-user backend signals an error of queue {0:#x}")]
     VuQueueErr(u16),
+
+    #[error("vhost-user backend is missing device feature {0:#x}")]
+    VuMissingDeviceFeature(u64),
+
+    #[error("vhost-user backend is missing protocol feature {0:x?}")]
+    VuMissingProtocolFeature(vu::VuFeature),
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;

--- a/alioth/src/virtio/virtio.rs
+++ b/alioth/src/virtio/virtio.rs
@@ -25,6 +25,7 @@ pub mod dev;
 pub mod pci;
 #[path = "queue/queue.rs"]
 pub mod queue;
+pub mod vu;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -48,6 +49,21 @@ pub enum Error {
 
     #[error("invalid msix vector {0}")]
     InvalidMsixVector(u16),
+
+    #[error("Invalid vhost user response message, want {0}, got {1}")]
+    InvalidVhostRespMsg(u32, u32),
+
+    #[error("Invalid vhost user response size, want {0}, get {1}")]
+    InvalidVhostRespSize(usize, usize),
+
+    #[error("Invalid vhost user response payload size, want {0}, got {1}")]
+    InvalidVhostRespPayloadSize(usize, u32),
+
+    #[error("vhost-user backend replied error code {0:#x} to request {1:#x}")]
+    VuRequestErr(u64, u32),
+
+    #[error("vhost-user backend signals an error of queue {0:#x}")]
+    VuQueueErr(u16),
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -57,6 +73,7 @@ bitflags! {
     pub struct VirtioFeature: u64 {
         const INDIRECT_DESC = 1 << 28;
         const EVENT_IDX = 1 << 29;
+        const VHOST_PROTOCOL = 1 << 30;
         const VERSION_1 = 1 << 32;
         const ACCESS_PLATFORM = 1 << 33;
         const RING_PACKED = 1 << 34;

--- a/alioth/src/virtio/vu.rs
+++ b/alioth/src/virtio/vu.rs
@@ -1,0 +1,341 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::{IoSlice, IoSliceMut, Read};
+use std::mem::{size_of, size_of_val};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::ptr::null_mut;
+
+use bitfield::bitfield;
+use bitflags::bitflags;
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
+use crate::ffi;
+use crate::virtio::{Error, Result};
+
+bitflags! {
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[repr(transparent)]
+    pub struct VuFeature: u64 {
+        const MQ = 1 << 0;
+        const LOG_SHMFD = 1 << 1;
+        const RARP = 1 << 2;
+        const REPLY_ACK = 1 << 3;
+        const MTU = 1 << 4;
+        const BACKEND_REQ = 1 << 5;
+        const CROSS_ENDIAN = 1 << 6;
+        const CRYPTO_SESSION = 1 << 7;
+        const PAGEFAULT = 1 << 8;
+        const CONFIG = 1 << 9;
+        const BACKEND_SEND_FD = 1 << 10;
+        const HOST_NOTIFIER = 1 << 11;
+        const INFLIGHT_SHMFD = 1 << 12;
+        const RESET_DEVICE = 1 << 13;
+        const INBAND_NOTIFICATIONS = 1 << 14;
+        const CONFIGURE_MEM_SLOTS = 1 << 15;
+        const STATUS = 1 << 16;
+        const XEN_MMAP = 1 << 17;
+        const SHARED_OBJECT = 1 << 18;
+        const DEVICE_STATE = 1 << 19;
+    }
+}
+
+pub const VHOST_USER_GET_FEATURES: u32 = 1;
+pub const VHOST_USER_SET_FEATURES: u32 = 2;
+pub const VHOST_USER_SET_OWNER: u32 = 3;
+#[deprecated]
+pub const VHOST_USER_RESET_OWNER: u32 = 4;
+pub const VHOST_USER_SET_MEM_TABLE: u32 = 5;
+pub const VHOST_USER_SET_LOG_BASE: u32 = 6;
+pub const VHOST_USER_SET_LOG_FD: u32 = 7;
+pub const VHOST_USER_SET_VIRTQ_NUM: u32 = 8;
+pub const VHOST_USER_SET_VIRTQ_ADDR: u32 = 9;
+pub const VHOST_USER_SET_VIRTQ_BASE: u32 = 10;
+pub const VHOST_USER_GET_VIRTQ_BASE: u32 = 11;
+pub const VHOST_USER_SET_VIRTQ_KICK: u32 = 12;
+pub const VHOST_USER_SET_VIRTQ_CALL: u32 = 13;
+pub const VHOST_USER_SET_VIRTQ_ERR: u32 = 14;
+pub const VHOST_USER_GET_PROTOCOL_FEATURES: u32 = 15;
+pub const VHOST_USER_SET_PROTOCOL_FEATURES: u32 = 16;
+pub const VHOST_USER_GET_QUEUE_NUM: u32 = 17;
+pub const VHOST_USER_SET_VIRTQ_ENABLE: u32 = 18;
+pub const VHOST_USER_SEND_RARP: u32 = 19;
+pub const VHOST_USER_NET_SET_MTU: u32 = 20;
+pub const VHOST_USER_SET_BACKEND_REQ_FD: u32 = 21;
+pub const VHOST_USER_IOTLB_MSG: u32 = 22;
+pub const VHOST_USER_SET_VIRTQ_ENDIAN: u32 = 23;
+pub const VHOST_USER_GET_CONFIG: u32 = 24;
+pub const VHOST_USER_SET_CONFIG: u32 = 25;
+pub const VHOST_USER_CREATE_CRYPTO_SESSION: u32 = 26;
+pub const VHOST_USER_CLOSE_CRYPTO_SESSION: u32 = 27;
+pub const VHOST_USER_POSTCOPY_ADVISE: u32 = 28;
+pub const VHOST_USER_POSTCOPY_LISTEN: u32 = 29;
+pub const VHOST_USER_POSTCOPY_END: u32 = 30;
+pub const VHOST_USER_GET_INFLIGHT_FD: u32 = 31;
+pub const VHOST_USER_SET_INFLIGHT_FD: u32 = 32;
+pub const VHOST_USER_GPU_SET_SOCKET: u32 = 33;
+pub const VHOST_USER_RESET_DEVICE: u32 = 34;
+pub const VHOST_USER_GET_MAX_MEM_SLOTS: u32 = 36;
+pub const VHOST_USER_ADD_MEM_REG: u32 = 37;
+pub const VHOST_USER_REM_MEM_REG: u32 = 38;
+pub const VHOST_USER_SET_STATUS: u32 = 39;
+pub const VHOST_USER_GET_STATUS: u32 = 40;
+pub const VHOST_USER_GET_SHARED_OBJECT: u32 = 41;
+pub const VHOST_USER_SET_DEVICE_STATE_FD: u32 = 42;
+pub const VHOST_USER_CHECK_DEVICE_STATE: u32 = 43;
+
+bitfield! {
+    #[derive(Copy, Clone, Default, AsBytes, FromBytes, FromZeroes)]
+    #[repr(transparent)]
+    pub struct MessageFlag(u32);
+    impl Debug;
+    need_reply, set_need_reply: 3;
+    reply, set_reply: 2;
+    version, set_version: 1, 0;
+}
+
+impl MessageFlag {
+    pub const VERSION_1: u32 = 0x1;
+    pub const REPLY: u32 = 1 << 2;
+    pub const NEED_REPLY: u32 = 1 << 3;
+    pub const fn sender() -> Self {
+        MessageFlag(MessageFlag::VERSION_1 | MessageFlag::NEED_REPLY)
+    }
+}
+
+#[derive(Debug, AsBytes, FromBytes, FromZeroes)]
+#[repr(C)]
+pub struct VirtqState {
+    pub index: u32,
+    pub val: u32,
+}
+
+#[derive(Debug, AsBytes, FromBytes, FromZeroes)]
+#[repr(C)]
+pub struct VirtqAddr {
+    pub index: u32,
+    pub flags: u32,
+    pub desc_hva: u64,
+    pub used_hva: u64,
+    pub avail_hva: u64,
+    pub log_guest_addr: u64,
+}
+
+#[derive(Debug, AsBytes, FromBytes, FromZeroes)]
+#[repr(C)]
+pub struct MemoryRegion {
+    pub gpa: u64,
+    pub size: u64,
+    pub hva: u64,
+    pub mmap_offset: u64,
+}
+
+#[derive(Debug, AsBytes, FromBytes, FromZeroes)]
+#[repr(C)]
+pub struct MemorySingleRegion {
+    pub _padding: u64,
+    pub region: MemoryRegion,
+}
+
+#[derive(Debug, AsBytes, FromBytes, FromZeroes)]
+#[repr(C)]
+pub struct MemoryMultipleRegion {
+    pub num: u32,
+    pub _padding: u32,
+    pub regions: [MemoryRegion; 8],
+}
+
+#[derive(Debug, AsBytes, FromBytes, FromZeroes)]
+#[repr(C)]
+pub struct DeviceConfig {
+    pub offset: u32,
+    pub size: u32,
+    pub flags: u32,
+    pub region: [u8; 256],
+}
+
+#[derive(AsBytes, FromBytes, FromZeroes)]
+#[repr(C)]
+pub struct Message {
+    pub request: u32,
+    pub flag: MessageFlag,
+    pub size: u32,
+}
+
+#[derive(Debug)]
+pub struct VuDev {
+    conn: UnixStream,
+}
+
+impl VuDev {
+    pub fn new<P: AsRef<Path>>(sock: P) -> Result<Self> {
+        Ok(VuDev {
+            conn: UnixStream::connect(sock)?,
+        })
+    }
+
+    fn send_msg<T: AsBytes, R: FromBytes + AsBytes>(
+        &self,
+        req: u32,
+        payload: &T,
+        fds: &[RawFd],
+    ) -> Result<R> {
+        let vhost_msg = Message {
+            request: req,
+            flag: MessageFlag::sender(),
+            size: size_of::<T>() as u32,
+        };
+        let bufs = [
+            IoSlice::new(vhost_msg.as_bytes()),
+            IoSlice::new(payload.as_bytes()),
+        ];
+        let fd_size = size_of_val(fds);
+        let mut cmsg_buf = if fds.is_empty() {
+            vec![]
+        } else {
+            vec![0u8; unsafe { libc::CMSG_SPACE(fd_size as _) } as _]
+        };
+        let uds_msg = libc::msghdr {
+            msg_name: null_mut(),
+            msg_namelen: 0,
+            msg_iov: bufs.as_ptr() as _,
+            msg_iovlen: if size_of::<T>() == 0 { 1 } else { 2 },
+            msg_control: if fds.is_empty() {
+                null_mut()
+            } else {
+                cmsg_buf.as_mut_ptr() as _
+            },
+            msg_controllen: cmsg_buf.len(),
+            msg_flags: 0,
+        };
+        if !fds.is_empty() {
+            let cmsg_ptr = unsafe { libc::CMSG_FIRSTHDR(&uds_msg) };
+            let cmsg = libc::cmsghdr {
+                cmsg_level: libc::SOL_SOCKET,
+                cmsg_type: libc::SCM_RIGHTS,
+                cmsg_len: unsafe { libc::CMSG_LEN(fd_size as _) } as _,
+            };
+            unsafe { std::ptr::write_unaligned(cmsg_ptr, cmsg) };
+            let data =
+                unsafe { std::slice::from_raw_parts_mut(libc::CMSG_DATA(cmsg_ptr), fd_size) };
+            data.copy_from_slice(fds.as_bytes());
+        }
+        ffi!(unsafe { libc::sendmsg(self.conn.as_raw_fd(), &uds_msg, 0) })?;
+
+        let mut resp = Message::new_zeroed();
+        let mut payload = R::new_zeroed();
+        let mut ret_code = u64::MAX;
+        let mut bufs = if size_of::<R>() == 0 {
+            [
+                IoSliceMut::new(resp.as_bytes_mut()),
+                IoSliceMut::new(ret_code.as_bytes_mut()),
+            ]
+        } else {
+            [
+                IoSliceMut::new(resp.as_bytes_mut()),
+                IoSliceMut::new(payload.as_bytes_mut()),
+            ]
+        };
+        let read_size = (&self.conn).read_vectored(&mut bufs)?;
+        let expect_size = size_of::<Message>() + bufs[1].len();
+        if read_size != expect_size {
+            return Err(Error::InvalidVhostRespSize(expect_size, read_size));
+        }
+        if resp.request != req {
+            return Err(Error::InvalidVhostRespMsg(req, resp.request));
+        }
+        if size_of::<R>() != 0 {
+            if resp.size != size_of::<R>() as u32 {
+                return Err(Error::InvalidVhostRespPayloadSize(
+                    size_of::<R>(),
+                    resp.size,
+                ));
+            }
+        } else {
+            if resp.size != size_of::<u64>() as u32 {
+                return Err(Error::InvalidVhostRespPayloadSize(
+                    size_of::<u64>(),
+                    resp.size,
+                ));
+            }
+            if ret_code != 0 {
+                return Err(Error::VuRequestErr(ret_code, req));
+            }
+        }
+        Ok(payload)
+    }
+
+    pub fn get_features(&self) -> Result<u64> {
+        self.send_msg(VHOST_USER_GET_FEATURES, &(), &[])
+    }
+    pub fn set_features(&self, payload: &u64) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_FEATURES, payload, &[])
+    }
+    pub fn get_protocol_features(&self) -> Result<u64> {
+        self.send_msg(VHOST_USER_GET_PROTOCOL_FEATURES, &(), &[])
+    }
+    pub fn set_protocol_features(&self, payload: &u64) -> Result<u64> {
+        self.send_msg(VHOST_USER_SET_PROTOCOL_FEATURES, payload, &[])
+    }
+    pub fn set_owner(&self) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_OWNER, &(), &[])
+    }
+    pub fn set_virtq_num(&self, payload: &VirtqState) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_VIRTQ_NUM, payload, &[])
+    }
+    pub fn set_virtq_addr(&self, payload: &VirtqAddr) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_VIRTQ_ADDR, payload, &[])
+    }
+    pub fn set_virtq_base(&self, payload: &VirtqState) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_VIRTQ_BASE, payload, &[])
+    }
+    pub fn get_config(&self, payload: &DeviceConfig) -> Result<DeviceConfig> {
+        self.send_msg(VHOST_USER_GET_CONFIG, payload, &[])
+    }
+    pub fn set_config(&self, payload: &DeviceConfig) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_CONFIG, payload, &[])
+    }
+    pub fn get_virtq_base(&self, payload: &VirtqState) -> Result<VirtqState> {
+        self.send_msg(VHOST_USER_GET_VIRTQ_BASE, payload, &[])
+    }
+    pub fn get_queue_num(&self) -> Result<u64> {
+        self.send_msg(VHOST_USER_GET_QUEUE_NUM, &(), &[])
+    }
+    pub fn set_virtq_kick(&self, payload: &u64, fd: RawFd) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_VIRTQ_KICK, payload, &[fd])
+    }
+    pub fn set_virtq_call(&self, payload: &u64, fd: RawFd) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_VIRTQ_CALL, payload, &[fd])
+    }
+    pub fn set_virtq_err(&self, payload: &u64, fd: RawFd) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_VIRTQ_ERR, payload, &[fd])
+    }
+    pub fn set_virtq_enable(&self, payload: &VirtqState) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_VIRTQ_ENABLE, payload, &[])
+    }
+    pub fn set_status(&self, payload: &u64) -> Result<()> {
+        self.send_msg(VHOST_USER_SET_STATUS, payload, &[])
+    }
+    pub fn get_status(&self) -> Result<u64> {
+        self.send_msg(VHOST_USER_GET_STATUS, &(), &[])
+    }
+    pub fn add_mem_region(&self, payload: &MemorySingleRegion, fd: RawFd) -> Result<()> {
+        self.send_msg(VHOST_USER_ADD_MEM_REG, payload, &[fd])
+    }
+    pub fn remove_mem_region(&self, payload: &MemorySingleRegion) -> Result<()> {
+        self.send_msg(VHOST_USER_REM_MEM_REG, payload, &[])
+    }
+}


### PR DESCRIPTION
A host directory can be shared with the guest by
1. virtiofsd[^1] flag: `--shared-dir /path/to/dir --socket-path /tmp/virtiofsd`
2. Alioth flag: `--fs vu,socket=/tmp/virtiofsd,tag=host-dir`

[^1]: https://gitlab.com/virtio-fs/virtiofsd