### PR TITLE
fix(fs): deregister the backend channel upon reset

### DIFF
--- a/alioth/src/virtio/dev/fs.rs
+++ b/alioth/src/virtio/dev/fs.rs
@@ -372,6 +372,11 @@ impl Virtio for VuFs {
         while let Some(fd) = self.error_fds.pop() {
             registry.deregister(&mut SourceFd(&fd.as_raw_fd())).unwrap();
         }
+        if let Some(channel) = self.vu_dev.get_channel() {
+            registry
+                .deregister(&mut SourceFd(&channel.as_raw_fd()))
+                .unwrap();
+        }
         while let Some(region) = self.regions.pop() {
             self.vu_dev
                 .remove_mem_region(&MemorySingleRegion {


### PR DESCRIPTION
Fixed: 359ab26fb216f ("feat(fs): support virtio-fs DAX mapping")