### PR TITLE
feat(pci)!: reserve a BDF before adding a device

### DIFF
--- a/alioth/src/pci/pci.rs
+++ b/alioth/src/pci/pci.rs
@@ -31,7 +31,7 @@ pub mod segment;
 use config::{HeaderData, PciConfig};
 
 bitfield! {
-    #[derive(Copy, Clone, Default, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
     pub struct Bdf(u16);
     impl Debug;
     bus, _: 15, 8;


### PR DESCRIPTION
MSI on aarch64 requires an additional devid, which is usually the device BDF. Thus the `MsiSender` of a PCI device needs to know the BDF. However, currently the BDF is unknown until the device has been plugged into the PCI bus.

This commit changes the API such that a BDF is reserved first before a device is plugged in. The reserved BDF then can be passed to the constructor of an `MsiSender`.