### PR TITLE
fix(mem)!: wrap `Action` in `Ok` instead of `Err`

### DIFF
--- a/alioth/src/device/fw_cfg/fw_cfg.rs
+++ b/alioth/src/device/fw_cfg/fw_cfg.rs
@@ -40,7 +40,7 @@ use crate::loader::linux::bootparams::{
     BootE820Entry, BootParams, E820_ACPI, E820_PMEM, E820_RAM, E820_RESERVED,
 };
 use crate::mem;
-use crate::mem::emulated::Mmio;
+use crate::mem::emulated::{Action, Mmio};
 use crate::mem::mapped::RamBus;
 #[cfg(target_arch = "x86_64")]
 use crate::mem::{MemRegionEntry, MemRegionType};
@@ -479,7 +479,7 @@ impl Mmio for Mutex<FwCfg> {
         Ok(ret)
     }
 
-    fn write(&self, offset: u64, size: u8, val: u64) -> mem::Result<()> {
+    fn write(&self, offset: u64, size: u8, val: u64) -> mem::Result<Action> {
         let mut fw_cfg = self.lock();
         let port = offset as u16 + PORT_SELECTOR;
         match (port, size) {
@@ -502,7 +502,7 @@ impl Mmio for Mutex<FwCfg> {
                 width = 2 * size as usize,
             ),
         };
-        Ok(())
+        Ok(Action::None)
     }
 }
 

--- a/alioth/src/device/pl011.rs
+++ b/alioth/src/device/pl011.rs
@@ -21,7 +21,7 @@ use parking_lot::Mutex;
 
 use crate::device::console::{Console, UartRecv};
 use crate::hv::IrqSender;
-use crate::mem::emulated::Mmio;
+use crate::mem::emulated::{Action, Mmio};
 use crate::{hv, mem};
 
 /// RW width 12/8 Data Register
@@ -228,7 +228,7 @@ where
         Ok(ret as u64)
     }
 
-    fn write(&self, offset: u64, _size: u8, val: u64) -> mem::Result<()> {
+    fn write(&self, offset: u64, _size: u8, val: u64) -> mem::Result<Action> {
         let mut reg = self.reg.lock();
         match offset {
             UART_DR => {
@@ -254,7 +254,7 @@ where
             UART_DMACR => reg.dmacr = val as u32,
             _ => {}
         }
-        Ok(())
+        Ok(Action::None)
     }
 }
 

--- a/alioth/src/device/pvpanic.rs
+++ b/alioth/src/device/pvpanic.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use bitflags::bitflags;
 
-use crate::mem::emulated::Mmio;
-use crate::mem::{self, Action, MemRegion};
+use crate::mem::emulated::{Action, Mmio};
+use crate::mem::{self, MemRegion};
 use crate::pci::cap::PciCapList;
 use crate::pci::config::{
     CommonHeader, DeviceHeader, EmulatedConfig, HeaderType, PciConfig, BAR_MEM64, BAR_PREFETCHABLE,
@@ -47,9 +47,9 @@ impl<const N: u64> Mmio for PvPanicBar<N> {
         Ok(PvPanicByte::all().bits() as u64)
     }
 
-    fn write(&self, _offset: u64, _size: u8, val: u64) -> mem::Result<()> {
+    fn write(&self, _offset: u64, _size: u8, val: u64) -> mem::Result<Action> {
         log::info!("pvpanic: {:x?}", PvPanicByte::from_bits_retain(val as u8));
-        Err(mem::Error::Action(Action::Shutdown))
+        Ok(Action::Shutdown)
     }
 }
 

--- a/alioth/src/device/serial.rs
+++ b/alioth/src/device/serial.rs
@@ -23,7 +23,7 @@ use parking_lot::Mutex;
 use crate::device::console::{Console, UartRecv};
 use crate::hv::IrqSender;
 use crate::mem;
-use crate::mem::emulated::Mmio;
+use crate::mem::emulated::{Action, Mmio};
 
 const TX_HOLDING_REGISTER: u16 = 0x0;
 const RX_BUFFER_REGISTER: u16 = 0x0;
@@ -229,7 +229,7 @@ where
         Ok(ret as u64)
     }
 
-    fn write(&self, offset: u64, _size: u8, val: u64) -> Result<(), mem::Error> {
+    fn write(&self, offset: u64, _size: u8, val: u64) -> mem::Result<Action> {
         let byte = val as u8;
         let mut reg = self.reg.lock();
         match offset as u16 {
@@ -278,7 +278,7 @@ where
             }
             _ => log::error!("{}: write unreachable offset {:#x}", self.name, offset),
         }
-        Ok(())
+        Ok(Action::None)
     }
 }
 

--- a/alioth/src/pci/segment.rs
+++ b/alioth/src/pci/segment.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use parking_lot::{Mutex, RwLock};
 
 use crate::mem;
-use crate::mem::emulated::Mmio;
+use crate::mem::emulated::{Action, Mmio};
 use crate::pci::config::PciConfig;
 use crate::pci::{Bdf, Pci, PciDevice, Result};
 
@@ -108,13 +108,13 @@ impl Mmio for PciSegment {
         }
     }
 
-    fn write(&self, offset: u64, size: u8, val: u64) -> Result<(), mem::Error> {
+    fn write(&self, offset: u64, size: u8, val: u64) -> mem::Result<Action> {
         let bdf = Bdf((offset >> 12) as u16);
         let configs = self.devices.read();
         if let Some(config) = configs.get(&bdf) {
             config.dev.config().write(offset & 0xfff, size, val)
         } else {
-            Ok(())
+            Ok(Action::None)
         }
     }
 }

--- a/alioth/src/virtio/dev/entropy.rs
+++ b/alioth/src/virtio/dev/entropy.rs
@@ -23,7 +23,7 @@ use mio::event::Event;
 use mio::Registry;
 
 use crate::mem;
-use crate::mem::emulated::Mmio;
+use crate::mem::emulated::{Action, Mmio};
 use crate::mem::mapped::RamBus;
 use crate::virtio::dev::{DevParam, DeviceId, Virtio};
 use crate::virtio::queue::handlers::reader_to_queue;
@@ -42,8 +42,8 @@ impl Mmio for EntropyConfig {
         Ok(0)
     }
 
-    fn write(&self, _offset: u64, _size: u8, _val: u64) -> mem::Result<()> {
-        Ok(())
+    fn write(&self, _offset: u64, _size: u8, _val: u64) -> mem::Result<Action> {
+        Ok(Action::None)
     }
 }
 

--- a/alioth/src/virtio/pci.rs
+++ b/alioth/src/virtio/pci.rs
@@ -25,7 +25,7 @@ use parking_lot::{Mutex, RwLock};
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 use crate::hv::{IoeventFd, IoeventFdRegistry, IrqFd, MsiSender};
-use crate::mem::emulated::Mmio;
+use crate::mem::emulated::{Action, Mmio};
 use crate::mem::{MemRange, MemRegion, MemRegionCallback, MemRegionEntry};
 use crate::pci::cap::{
     MsixCap, MsixCapMmio, MsixCapOffset, MsixMsgCtrl, MsixTableEntry, MsixTableMmio,
@@ -371,7 +371,7 @@ where
         Ok(ret)
     }
 
-    fn write(&self, offset: u64, size: u8, val: u64) -> mem::Result<()> {
+    fn write(&self, offset: u64, size: u8, val: u64) -> mem::Result<Action> {
         let reg = &*self.reg;
         match (offset as usize, size as usize) {
             VirtioCommonCfg::LAYOUT_DEVICE_FEATURE_SELECT => {
@@ -515,7 +515,7 @@ where
                 );
             }
         }
-        Ok(())
+        Ok(Action::None)
     }
 }
 


### PR DESCRIPTION
Conceptually the side effect of MMIO write is not an Error.

All `Action`s should be handled internally.