### PR TITLE
fix(mem)!: remove legacy address allocation APIs

### DIFF
--- a/alioth/src/board/aarch64.rs
+++ b/alioth/src/board/aarch64.rs
@@ -30,7 +30,7 @@ use crate::firmware::dt::{DeviceTree, Node, PropVal};
 use crate::hv::{GicV2, GicV3, Hypervisor, Its, Vcpu, Vm};
 use crate::loader::{ExecType, InitState};
 use crate::mem::mapped::ArcMemPages;
-use crate::mem::{AddrOpt, MemRegion, MemRegionType};
+use crate::mem::{MemRegion, MemRegionType};
 
 enum Gic<V>
 where
@@ -109,7 +109,7 @@ where
         #[cfg(not(target_os = "linux"))]
         let pages_low = ArcMemPages::from_anonymous(low_mem_size as usize, None)?;
         memory.add_region(
-            AddrOpt::Fixed(RAM_32_START),
+            RAM_32_START,
             Arc::new(MemRegion::with_mapped(pages_low, MemRegionType::Ram)),
         )?;
 
@@ -120,7 +120,7 @@ where
             #[cfg(not(target_os = "linux"))]
             let pages_high = ArcMemPages::from_anonymous(high_mem_size, None)?;
             memory.add_region(
-                AddrOpt::Fixed(MEM_64_START),
+                MEM_64_START,
                 Arc::new(MemRegion::with_mapped(pages_high, MemRegionType::Ram)),
             )?;
         }

--- a/alioth/src/board/x86_64.rs
+++ b/alioth/src/board/x86_64.rs
@@ -36,7 +36,7 @@ use crate::firmware::acpi::{
 use crate::hv::{Coco, Hypervisor, Vcpu, Vm};
 use crate::loader::InitState;
 use crate::mem::mapped::ArcMemPages;
-use crate::mem::{AddrOpt, MemRange, MemRegion, MemRegionEntry, MemRegionType};
+use crate::mem::{MemRange, MemRegion, MemRegionEntry, MemRegionType};
 use crate::utils::wrapping_sum;
 
 pub struct ArchBoard<V> {
@@ -266,7 +266,7 @@ where
             ],
             callbacks: Mutex::new(vec![]),
         };
-        memory.add_region(AddrOpt::Fixed(0), Arc::new(region_low))?;
+        memory.add_region(0, Arc::new(region_low))?;
         if let Some(coco) = &self.config.coco {
             ram_bus.register_encrypted_pages(&pages_low)?;
             if let Coco::AmdSnp { .. } = coco {
@@ -277,7 +277,7 @@ where
             let mem_hi_size = config.mem_size - RAM_32_SIZE;
             let mem_hi = ArcMemPages::from_memfd(mem_hi_size as usize, None, Some(c"ram-high"))?;
             let region_hi = MemRegion::with_mapped(mem_hi.clone(), MemRegionType::Ram);
-            memory.add_region(AddrOpt::Fixed(MEM_64_START), Arc::new(region_hi))?;
+            memory.add_region(MEM_64_START, Arc::new(region_hi))?;
             if let Some(coco) = &self.config.coco {
                 ram_bus.register_encrypted_pages(&mem_hi)?;
                 if let Coco::AmdSnp { .. } = coco {

--- a/alioth/src/loader/firmware/x86_64.rs
+++ b/alioth/src/loader/firmware/x86_64.rs
@@ -21,7 +21,7 @@ use crate::arch::layout::MEM_64_START;
 use crate::arch::reg::{Cr0, DtReg, DtRegVal, Reg, Rflags, SReg, SegAccess, SegReg, SegRegVal};
 use crate::loader::{InitState, Result};
 use crate::mem::mapped::ArcMemPages;
-use crate::mem::{AddrOpt, MemRegion, MemRegionType, Memory};
+use crate::mem::{MemRegion, MemRegionType, Memory};
 
 pub fn load<P: AsRef<Path>>(memory: &Memory, path: P) -> Result<(InitState, ArcMemPages)> {
     let mut file = File::open(path)?;
@@ -33,7 +33,7 @@ pub fn load<P: AsRef<Path>>(memory: &Memory, path: P) -> Result<(InitState, ArcM
 
     let gpa = MEM_64_START - size;
     memory.add_region(
-        AddrOpt::Fixed(gpa),
+        gpa,
         Arc::new(MemRegion::with_mapped(rom.clone(), MemRegionType::Reserved)),
     )?;
     let boot_cs = SegRegVal {

--- a/alioth/src/mem/addressable.rs
+++ b/alioth/src/mem/addressable.rs
@@ -14,7 +14,6 @@
 
 use std::ops::RangeBounds;
 
-use crate::align_up;
 use crate::mem::{Error, Result};
 
 pub trait SlotBackend {
@@ -125,45 +124,6 @@ where
                 // TODO add some compiler hint to eliminate bound check?
                 Ok(&mut self.slots[index].backend)
             }
-        }
-    }
-
-    pub fn add_within(&mut self, start: u64, max: u64, align: u64, backend: B) -> Result<u64> {
-        if backend.size() == 0 {
-            return Err(Error::ZeroSizedSlot);
-        }
-        let mut index = match self.slots.binary_search_by_key(&start, |s| s.addr) {
-            Ok(idx) | Err(idx) => idx,
-        };
-        let mut prev_end = if index > 0 {
-            let prev = &self.slots[index - 1];
-            prev.max_addr().checked_add(1).ok_or(Error::CanotAllocate)?
-        } else {
-            0
-        };
-        prev_end = std::cmp::max(prev_end, start);
-        loop {
-            let addr = align_up!(prev_end, align);
-            if addr < prev_end {
-                break Err(Error::CanotAllocate);
-            }
-            let Some(addr_max) = addr.checked_add(backend.size() - 1) else {
-                break Err(Error::CanotAllocate);
-            };
-            if addr_max > max {
-                break Err(Error::CanotAllocate);
-            }
-            if index < self.slots.len() && addr_max >= self.slots[index].addr {
-                prev_end = self.slots[index]
-                    .max_addr()
-                    .checked_add(1)
-                    .ok_or(Error::CanotAllocate)?;
-                index += 1;
-                continue;
-            }
-            let backend = Slot { addr, backend };
-            self.slots.insert(index, backend);
-            break Ok(addr);
         }
     }
 
@@ -335,89 +295,5 @@ mod test {
             memory.add(0u64.wrapping_sub(0x1000), Backend { size: 0x1000 }),
             Err(_)
         )
-    }
-
-    #[test]
-    fn test_add_within() {
-        let mut memory = Addressable::<Backend>::new();
-        memory
-            .add_within(0, 0x1000, 1, Backend { size: 0 })
-            .unwrap_err();
-
-        assert_matches!(
-            memory.add_within(0xff0, u64::MAX, 0x1000, Backend { size: 0x1000 }),
-            Ok(0x1000)
-        );
-        // slots: [0x1000, 0x1fff]
-
-        assert_matches!(
-            memory.add_within(0, u64::MAX, 0x1000, Backend { size: 0x2000 }),
-            Ok(0x2000)
-        );
-        // slots: [0x1000, 0x1fff], [0x2000, 0x3fff]
-
-        memory
-            .add_within(0, 0x3fff, 0x1000, Backend { size: 0x2000 })
-            .unwrap_err();
-
-        assert_matches!(
-            memory.add_within(0, u64::MAX, 0x1000, Backend { size: 0x1000 }),
-            Ok(0)
-        );
-        // slots: [0, 0xfff], [0x1000, 0x1fff], [0x2000, 0x3fff]
-
-        assert_matches!(
-            memory.add_within(0x5000, u64::MAX, 0x1000, Backend { size: 0x1000 }),
-            Ok(0x5000)
-        );
-        // slots: [0, 0xfff], [0x1000, 0x1fff], [0x2000, 0x3fff],
-        // [0x5000, 0x5fff]
-
-        assert_matches!(
-            memory.add_within(0, u64::MAX, 0x4000, Backend { size: 0x1000 }),
-            Ok(0x4000)
-        );
-        // slots: [0, 0xfff], [0x1000, 0x1fff], [0x2000, 0x3fff],
-        // [0x4000, 0x4fff], [0x5000, 0x5fff]
-
-        assert_matches!(
-            memory.add_within(
-                0u64.wrapping_sub(0x9000),
-                u64::MAX,
-                0x2000,
-                Backend { size: 0x1000 }
-            ),
-            Ok(0xffff_ffff_ffff_8000)
-        );
-        // slots: [0, 0xfff], [0x1000, 0x1fff], [0x2000, 0x3fff],
-        // [0x4000, 0x4fff], [0x5000, 0x5fff],
-        // [0xffff_ffff_ffff_8000, 0xffff_ffff_ffff_8fff]
-
-        assert_matches!(
-            memory.add_within(
-                0u64.wrapping_sub(0x4000),
-                u64::MAX,
-                0x1000,
-                Backend { size: 0x1000 }
-            ),
-            Ok(0xffff_ffff_ffff_c000)
-        );
-        // slots: [0, 0xfff], [0x1000, 0x1fff], [0x2000, 0x3fff],
-        // [0x4000, 0x4fff], [0x5000, 0x5fff],
-        // [0xffff_ffff_ffff_8000, 0xffff_ffff_ffff_8fff],
-        // [0xffff_ffff_ffff_c000, 0xffff_ffff_ffff_cfff]
-
-        memory
-            .add_within(
-                0u64.wrapping_sub(0x9000),
-                u64::MAX,
-                0x1000,
-                Backend { size: 0x4000 },
-            )
-            .unwrap_err();
-
-        memory
-            .add_within(u64::MAX - 1, u64::MAX, 0x1000, Backend { size: 0x1000 })
-            .unwrap_err();
     }
 }

--- a/alioth/src/pci/config.rs
+++ b/alioth/src/pci/config.rs
@@ -22,7 +22,6 @@ use parking_lot::RwLock;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 use crate::mem::emulated::{Action, ChangeLayout, Mmio};
-use crate::mem::AddrOpt;
 use crate::pci::cap::PciCapList;
 use crate::pci::{Bdf, PciBar};
 use crate::{assign_bits, mask_bits, mem, unsafe_impl_zerocopy};
@@ -147,7 +146,7 @@ impl ChangeLayout for UpdateCommandCallback {
                         addr |= (self.bars[i + 1] as u64) << 32;
                     }
                     if self.current.contains(Command::MEM) {
-                        memory.add_region(AddrOpt::Fixed(addr), region.clone())?;
+                        memory.add_region(addr, region.clone())?;
                     } else {
                         memory.remove_region(addr)?;
                     }
@@ -158,7 +157,7 @@ impl ChangeLayout for UpdateCommandCallback {
                     }
                     let port = (bar & !BAR_IO_MASK) as u16;
                     if self.current.contains(Command::IO) {
-                        memory.add_io_region(Some(port), region.clone())?;
+                        memory.add_io_region(port, region.clone())?;
                     } else {
                         memory.remove_io_region(port)?;
                     }
@@ -188,12 +187,12 @@ impl ChangeLayout for MoveBarCallback {
             let src_port = self.src & !(BAR_IO_MASK as u64);
             let dst_port = self.dst & !(BAR_IO_MASK as u64);
             let region = memory.remove_io_region(src_port as u16)?;
-            memory.add_io_region(Some(dst_port as u16), region)?;
+            memory.add_io_region(dst_port as u16, region)?;
         } else {
             let src_addr = self.src & !(BAR_MEM_MASK as u64);
             let dst_addr = self.dst & !(BAR_MEM_MASK as u64);
             let region = memory.remove_region(src_addr)?;
-            memory.add_region(AddrOpt::Fixed(dst_addr), region)?;
+            memory.add_region(dst_addr, region)?;
         }
         Ok(())
     }

--- a/alioth/src/vm.rs
+++ b/alioth/src/vm.rs
@@ -34,7 +34,7 @@ use crate::hv::{self, Hypervisor, IoeventFdRegistry, Vm, VmConfig};
 use crate::loader::{self, Payload};
 use crate::mem::Memory;
 #[cfg(target_arch = "aarch64")]
-use crate::mem::{AddrOpt, MemRegion, MemRegionType};
+use crate::mem::{MemRegion, MemRegionType};
 use crate::pci::bus::PciBus;
 use crate::pci::{Bdf, PciDevice};
 use crate::virtio::dev::{DevParam, Virtio, VirtioDevice};
@@ -156,7 +156,7 @@ where
         let irq_line = self.board.vm.create_irq_sender(1)?;
         let pl011_dev = Pl011::new(PL011_START, irq_line)?;
         self.board.mmio_devs.write().push((
-            AddrOpt::Fixed(PL011_START),
+            PL011_START,
             Arc::new(MemRegion::with_emulated(
                 Arc::new(pl011_dev),
                 MemRegionType::Hidden,


### PR DESCRIPTION
It turns out ad-hoc address allocation is a bad idea.