### PR TITLE
ci: avoid nightly rust being installed every time

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Install toolchain
+        run: rustup target add ${{ matrix.target.name }}
+      - name: Get stable rust version
+        id: rust-version
+        run: echo RUST_VERSION=$(cargo +stable --version | cut -d ' ' -f 2) >> "$GITHUB_OUTPUT"
       - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
@@ -35,16 +40,16 @@ jobs:
             ~/.cargo/git/db/
             ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
             target/
-          key: ${{ matrix.target.name }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install toolchain
-        run: rustup target add ${{ matrix.target.name }}
+          key: ${{ matrix.target.name }}-cargo-${{ steps.rust-version.outputs.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Build
         run: cargo build --verbose --target ${{ matrix.target.name }}
         if: matrix.target.name != 'aarch64-unknown-linux-gnu'
       - name: Format
         run: > 
-          rustup toolchain install nightly &&
-          rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt &&
+          cargo +nightly --version || (
+            rustup toolchain install nightly &&
+            rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
+          ) &&
           cargo +nightly fmt --check
         if: matrix.target.name == 'x86_64-unknown-linux-gnu'
       - name: Run tests


### PR DESCRIPTION
- if the cached toolchain has nightly rust, just use it,
- install a new nightly rust if there is a new stable rust.