### PR TITLE
fix(board)!: reset PCI device config space

### DIFF
--- a/alioth/src/board/board.rs
+++ b/alioth/src/board/board.rs
@@ -302,6 +302,7 @@ where
                 let devices = self.pci_bus.segment.devices.read();
                 for (bdf, dev) in devices.iter() {
                     dev.dev.reset().context(error::ResetPci { bdf: *bdf })?;
+                    dev.dev.config().reset();
                 }
                 self.memory.reset()?;
             }

--- a/alioth/src/mem/emulated.rs
+++ b/alioth/src/mem/emulated.rs
@@ -109,7 +109,7 @@ pub struct MmioBus<R = MmioRange>
 where
     R: Debug + SlotBackend,
 {
-    inner: RwLock<Addressable<R>>,
+    pub(crate) inner: RwLock<Addressable<R>>,
 }
 
 impl<R> Default for MmioBus<R>

--- a/alioth/src/pci/cap.rs
+++ b/alioth/src/pci/cap.rs
@@ -126,6 +126,7 @@ impl Default for MsixTableEntry {
 
 pub trait PciCap: Mmio {
     fn set_next(&mut self, val: u8);
+    fn reset(&self);
 }
 
 impl SlotBackend for Box<dyn PciCap> {
@@ -168,6 +169,13 @@ impl PciCapList {
 
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
+    }
+
+    pub fn reset(&self) {
+        let inner = self.inner.inner.read();
+        for (_, cap) in inner.iter() {
+            cap.reset();
+        }
     }
 }
 
@@ -234,6 +242,12 @@ impl Mmio for MsixCapMmio {
 impl PciCap for MsixCapMmio {
     fn set_next(&mut self, val: u8) {
         self.cap.write().header.next = val;
+    }
+
+    fn reset(&self) {
+        let mut cap = self.cap.write();
+        cap.control.set_enabled(false);
+        cap.control.set_masked(false);
     }
 }
 

--- a/alioth/src/pci/config.rs
+++ b/alioth/src/pci/config.rs
@@ -358,6 +358,11 @@ impl EmulatedHeader {
         let mut header = self.data.write();
         header.set_command(command)
     }
+
+    pub fn reset(&self) {
+        let mut header = self.data.write();
+        header.set_command(Command::empty());
+    }
 }
 
 impl Mmio for EmulatedHeader {
@@ -393,6 +398,7 @@ impl Mmio for EmulatedHeader {
 
 pub trait PciConfig: Mmio {
     fn get_header(&self) -> &EmulatedHeader;
+    fn reset(&self);
 }
 
 #[derive(Debug)]
@@ -449,5 +455,10 @@ impl EmulatedConfig {
 impl PciConfig for EmulatedConfig {
     fn get_header(&self) -> &EmulatedHeader {
         &self.header
+    }
+
+    fn reset(&self) {
+        self.header.reset();
+        self.caps.reset();
     }
 }

--- a/alioth/src/virtio/pci.rs
+++ b/alioth/src/virtio/pci.rs
@@ -593,6 +593,8 @@ impl PciCap for VirtioPciCap {
     fn set_next(&mut self, val: u8) {
         self.header.next = val
     }
+
+    fn reset(&self) {}
 }
 
 #[repr(C, align(4))]
@@ -608,6 +610,7 @@ impl PciCap for VirtioPciCap64 {
     fn set_next(&mut self, val: u8) {
         PciCap::set_next(&mut self.cap, val)
     }
+    fn reset(&self) {}
 }
 
 #[repr(C, align(4))]
@@ -622,6 +625,7 @@ impl PciCap for VirtioPciNotifyCap {
     fn set_next(&mut self, val: u8) {
         self.cap.header.next = val;
     }
+    fn reset(&self) {}
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Without the fix, after a reboot, while PCI device resources have been removed from the memory bus, the config space Command register may still have the MEM and IO bit on.

Fixes: bc5ee80a77ce ("fix(pci): do not add resources to memory at boot")