### PR TITLE
Add help messages to command line interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "serde",
+ "serde-aco",
  "snafu",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,17 @@ version = "0.4.0"
 dependencies = [
  "assert_matches",
  "serde",
+ "serde-aco-derive",
  "serde_bytes",
+]
+
+[[package]]
+name = "serde-aco-derive"
+version = "0.4.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["alioth", "alioth-cli", "macros", "serde-aco"]
+members = ["alioth", "alioth-cli", "macros", "serde-aco", "serde-aco-derive"]
 resolver = "2"
 
 [workspace.package]
@@ -16,7 +16,11 @@ snafu = "0.8.4"
 macros = { version = "0.4.0", path = "macros", package = "alioth-macros" }
 alioth = { version = "0.4.0", path = "alioth" }
 serde-aco = { version = "0.4.0", path = "serde-aco" }
+serde-aco-derive = { version = "0.4.0", path = "serde-aco-derive" }
 assert_matches = "1"
+proc-macro2 = "1"
+syn = { version = "2", features = ["full"] }
+quote = { version = "1" }
 
 [profile.release]
 lto = true

--- a/alioth-cli/src/main.rs
+++ b/alioth-cli/src/main.rs
@@ -50,16 +50,18 @@ use snafu::{ResultExt, Snafu};
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 struct Cli {
-    #[arg(short, long)]
+    #[arg(short, long, value_name = "SPEC")]
     /// Loglevel specification, see
-    /// https://docs.rs/flexi_logger/0.25.5/flexi_logger/struct.LogSpecification.html.
+    /// https://docs.rs/flexi_logger/latest/flexi_logger/struct.LogSpecification.html.
     /// If not set, environment variable $RUST_LOG is used.
     pub log_spec: Option<String>,
 
+    /// Log to file instead of STDERR.
     #[arg(long)]
     pub log_to_file: bool,
 
-    #[arg(long)]
+    /// Path to a directory where the log file is stored.
+    #[arg(long, value_name = "PATH")]
     pub log_dir: Option<PathBuf>,
 
     #[command(subcommand)]
@@ -68,6 +70,7 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    /// Create and boot a virtual machine.
     Run(RunArgs),
 }
 
@@ -124,31 +127,39 @@ vhost-user process listening on socket `/path/to/socket=1`, these
     -o id_fs,socket=/path/to/socket=1"#;
 
 #[derive(Args, Debug, Clone)]
+#[command(arg_required_else_help = true)]
 struct RunArgs {
     #[arg(long, help(
         help_text::<Hypervisor>("Specify the Hypervisor to run on.")
     ), value_name = "HV")]
     hypervisor: Option<String>,
 
-    #[arg(short, long)]
+    /// Path to a Linux kernel image.
+    #[arg(short, long, value_name = "PATH")]
     kernel: Option<PathBuf>,
 
+    /// Path to an ELF kernel with PVH note.
     #[cfg(target_arch = "x86_64")]
-    #[arg(long)]
+    #[arg(long, value_name = "PATH")]
     pvh: Option<PathBuf>,
 
-    #[arg(long, short)]
+    /// Path to a firmware image.
+    #[arg(long, short, value_name = "PATH")]
     firmware: Option<PathBuf>,
 
-    #[arg(short, long)]
+    /// Command line to pass to the kernel, e.g. `console=ttyS0`.
+    #[arg(short, long, value_name = "ARGS")]
     cmd_line: Option<String>,
 
-    #[arg(short, long)]
+    /// Path to an initramfs image.
+    #[arg(short, long, value_name = "PATH")]
     initramfs: Option<PathBuf>,
 
+    /// Number of VCPUs assigned to the guest.
     #[arg(long, default_value_t = 1)]
     num_cpu: u32,
 
+    /// DEPRECATED: Use --memory instead.
     #[arg(long, default_value = "1G")]
     mem_size: String,
 
@@ -157,6 +168,7 @@ struct RunArgs {
     ))]
     memory: Option<String>,
 
+    /// Add a pvpanic device.
     #[arg(long)]
     pvpanic: bool,
 
@@ -166,6 +178,7 @@ struct RunArgs {
     ), value_name = "ITEM")]
     fw_cfgs: Vec<String>,
 
+    /// Add a VirtIO entropy device.
     #[arg(long)]
     entropy: bool,
 

--- a/alioth-cli/src/main.rs
+++ b/alioth-cli/src/main.rs
@@ -65,7 +65,7 @@ struct Cli {
     pub log_dir: Option<PathBuf>,
 
     #[command(subcommand)]
-    pub cmd: Option<Command>,
+    pub cmd: Command,
 }
 
 #[derive(Subcommand, Debug)]
@@ -470,11 +470,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION"),
     );
-    let Some(cmd) = cli.cmd else {
-        return Ok(());
-    };
 
-    match cmd {
+    match cli.cmd {
         Command::Run(args) => main_run(args)?,
     }
     Ok(())

--- a/alioth-cli/src/main.rs
+++ b/alioth-cli/src/main.rs
@@ -108,6 +108,21 @@ enum VsockParam {
     Vhost(VhostVsockParam),
 }
 
+const DOC_OBJECTS: &str = r#"Supply additional data to other command line flags.
+* <id>,<value>
+
+Any value that comes after an equal sign(=) and contains a comma(,)
+or equal sign can be supplied using this flag. `<id>` must start
+with `id_` and `<id>` cannot contain any comma or equal sign.
+
+Example: assuming we are going a add a virtio-blk device backed by
+`/path/to/disk,2024.img` and a virtio-fs device backed by a
+vhost-user process listening on socket `/path/to/socket=1`, these
+2 devices can be expressed in the command line as follows:
+    --blk path=id_blk --fs vu,socket=id_fs,tag=shared-dir \
+    -o id_blk,/path/to/disk,2024.img \
+    -o id_fs,socket=/path/to/socket=1"#;
+
 #[derive(Args, Debug, Clone)]
 struct RunArgs {
     #[arg(long, help(
@@ -188,7 +203,7 @@ struct RunArgs {
     ))]
     vfio: Vec<String>,
 
-    #[arg(short, long("object"))]
+    #[arg(short, long("object"), help = DOC_OBJECTS, value_name = "OBJECT")]
     objects: Vec<String>,
 }
 

--- a/alioth/Cargo.toml
+++ b/alioth/Cargo.toml
@@ -20,6 +20,7 @@ libc = "0.2.150"
 parking_lot.workspace = true
 macros.workspace = true
 serde.workspace = true
+serde-aco.workspace = true
 snafu.workspace = true
 
 [dev-dependencies]

--- a/alioth/src/arch/x86_64/sev.rs
+++ b/alioth/src/arch/x86_64/sev.rs
@@ -14,9 +14,13 @@
 
 use bitfield::bitfield;
 use serde::{Deserialize, Serialize};
+use serde_aco::Help;
 
 bitfield! {
-    #[derive(Copy, Clone, Serialize, Deserialize)]
+    /// AMD SEV guest policy
+    ///
+    /// From Secure Encrypted Virtualization API Version 0.24, Revision 3.24, Ch.2, Table 2.
+    #[derive(Copy, Clone, Serialize, Deserialize, Help)]
     pub struct SevPolicy(u32);
     impl Debug;
     pub no_debug, set_no_debug: 0;
@@ -32,8 +36,8 @@ bitfield! {
 bitfield! {
     /// AMD SEV-SNP guest policy
     ///
-    /// From SEV SNP Firmware ABI Specification, Revision 1.55, Sec.4.3.
-    #[derive(Copy, Clone, Serialize, Deserialize)]
+    /// From SEV SNP Firmware ABI Specification, Revision 1.55, Sec.4.3, Table 9.
+    #[derive(Copy, Clone, Serialize, Deserialize, Help)]
     pub struct SnpPolicy(u64);
     impl Debug;
     pub api_minor, set_api_minor: 7,0;

--- a/alioth/src/device/fw_cfg/fw_cfg.rs
+++ b/alioth/src/device/fw_cfg/fw_cfg.rs
@@ -31,6 +31,7 @@ use macros::Layout;
 use parking_lot::Mutex;
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
+use serde_aco::Help;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[cfg(target_arch = "x86_64")]
@@ -505,15 +506,22 @@ impl Mmio for Mutex<FwCfg> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Deserialize, Debug, Help)]
 pub enum FwCfgContentParam {
+    /// Path to a file with binary contents.
+    #[serde(alias = "file")]
     File(PathBuf),
+    /// A UTF-8 encoded string.
+    #[serde(alias = "string")]
     String(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Help)]
 pub struct FwCfgItemParam {
+    /// Selector key of an item.
     pub name: String,
+    /// Item content.
+    #[serde_aco(flatten)]
     pub content: FwCfgContentParam,
 }
 

--- a/alioth/src/hv/hv.rs
+++ b/alioth/src/hv/hv.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use serde::Deserialize;
+use serde_aco::Help;
 use snafu::Snafu;
 
 #[cfg(target_arch = "x86_64")]
@@ -234,14 +235,24 @@ pub trait Its: Debug + Send + Sync + 'static {
     fn init(&self) -> Result<()>;
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Help)]
 pub enum Coco {
+    /// Enable AMD SEV or SEV-ES.
     #[cfg(target_arch = "x86_64")]
     #[serde(alias = "sev")]
-    AmdSev { policy: SevPolicy },
+    AmdSev {
+        /// SEV policy, 0x1 for SEV, 0x5 for SEV-ES.
+        /// SEV API Ver 0.24, Rev 3.24, Ch.2, Table 2.
+        policy: SevPolicy,
+    },
+    /// Enable AMD SEV-SNP.
     #[cfg(target_arch = "x86_64")]
     #[serde(alias = "snp", alias = "sev-snp")]
-    AmdSnp { policy: SnpPolicy },
+    AmdSnp {
+        /// SEV-SNP policy, e.g. 0x30000.
+        /// SNP Firmware ABI Spec, Rev 1.55, Sec.4.3, Table 9.
+        policy: SnpPolicy,
+    },
 }
 
 #[derive(Debug)]

--- a/alioth/src/hv/kvm/kvm.rs
+++ b/alioth/src/hv/kvm/kvm.rs
@@ -42,6 +42,7 @@ use std::sync::Arc;
 use parking_lot::lock_api::RwLock;
 use parking_lot::Mutex;
 use serde::Deserialize;
+use serde_aco::Help;
 use snafu::{ResultExt, Snafu};
 
 use crate::errors::{trace_error, DebugTrace};
@@ -116,12 +117,12 @@ pub struct Kvm {
     config: KvmConfig,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Default, Clone, Help)]
 pub struct KvmConfig {
-    #[serde(default)]
+    /// Path to the KVM device. [default: /dev/kvm]
     pub dev_kvm: Option<PathBuf>,
+    /// Path to the AMD SEV device. [default: /dev/sev]
     #[cfg(target_arch = "x86_64")]
-    #[serde(default)]
     pub dev_sev: Option<PathBuf>,
 }
 

--- a/alioth/src/mem/mem.rs
+++ b/alioth/src/mem/mem.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use serde::Deserialize;
+use serde_aco::Help;
 use snafu::Snafu;
 
 use crate::errors::{trace_error, DebugTrace};
@@ -78,24 +79,31 @@ fn default_memory_size() -> u64 {
     1 << 30
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Help)]
 pub struct MemConfig {
+    /// Total guest memory size in bytes. [default: 1G]
     #[serde(default = "default_memory_size")]
     pub size: u64,
+    /// Host backend [default: anon]
     #[serde(default)]
     pub backend: MemBackend,
+    /// mmap() guest memory with MAP_SHARED or MAP_PRIVATE.
+    /// [default: false]
     #[serde(default)]
     pub shared: bool,
+    /// Enable transparent hugepage. [default: false]
     #[cfg(target_os = "linux")]
     #[serde(default, alias = "thp")]
     pub transparent_hugepage: bool,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Help)]
 pub enum MemBackend {
+    /// Anonymous memory by MAP_ANONYMOUS.
     #[default]
     #[serde(alias = "anon")]
     Anonymous,
+    /// Anonymous file by memfd_create(). Always uses MAP_SHARED.
     #[cfg(target_os = "linux")]
     #[serde(alias = "memfd")]
     Memfd,

--- a/alioth/src/net/net.rs
+++ b/alioth/src/net/net.rs
@@ -14,11 +14,18 @@
 
 use serde::de::{self, Visitor};
 use serde::Deserialize;
+use serde_aco::{Help, TypedHelp};
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[derive(Debug, Default, FromBytes, FromZeroes, AsBytes, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct MacAddr([u8; 6]);
+
+impl Help for MacAddr {
+    fn help() -> TypedHelp {
+        TypedHelp::Custom { desc: "mac-addr" }
+    }
+}
 
 struct MacAddrVisitor;
 

--- a/alioth/src/vfio/vfio.rs
+++ b/alioth/src/vfio/vfio.rs
@@ -21,6 +21,7 @@ pub mod pci;
 use std::path::PathBuf;
 
 use serde::Deserialize;
+use serde_aco::Help;
 use snafu::Snafu;
 
 use crate::errors::{trace_error, DebugTrace};
@@ -46,7 +47,8 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Help)]
 pub struct VfioParam {
+    /// Path to a VFIO cdev, e.g. /dev/vfio/devices/vfio0.
     pub cdev: PathBuf,
 }

--- a/alioth/src/virtio/dev/blk.rs
+++ b/alioth/src/virtio/dev/blk.rs
@@ -21,6 +21,7 @@ use bitflags::bitflags;
 use mio::event::Event;
 use mio::Registry;
 use serde::Deserialize;
+use serde_aco::Help;
 use snafu::ResultExt;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
@@ -123,9 +124,11 @@ pub struct BlockConfig {
 }
 impl_mmio_for_zerocopy!(BlockConfig);
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Help)]
 pub struct BlockParam {
+    /// Path to a raw-formatted disk image.
     pub path: PathBuf,
+    /// Set the device as readonly. [default: false]
     #[serde(default)]
     pub readonly: bool,
 }

--- a/alioth/src/virtio/dev/fs.rs
+++ b/alioth/src/virtio/dev/fs.rs
@@ -29,6 +29,7 @@ use mio::event::Event;
 use mio::unix::SourceFd;
 use mio::{Interest, Registry, Token};
 use serde::Deserialize;
+use serde_aco::Help;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 use crate::hv::IoeventFd;
@@ -151,10 +152,14 @@ impl VuFs {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Help)]
 pub struct VuFsParam {
+    /// Path to the vhost-user UNIX domain socket.
     pub socket: PathBuf,
+    /// Mount tag seen by the guest.
     pub tag: Option<String>,
+    /// Size of memory region for DAX in bytes.
+    /// 0 means no DAX. [default: 0]
     #[serde(default)]
     pub dax_window: usize,
 }

--- a/alioth/src/virtio/dev/net/net.rs
+++ b/alioth/src/virtio/dev/net/net.rs
@@ -28,6 +28,7 @@ use mio::event::Event;
 use mio::unix::SourceFd;
 use mio::{Interest, Registry, Token};
 use serde::Deserialize;
+use serde_aco::Help;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 use crate::mem::mapped::RamBus;
@@ -143,12 +144,23 @@ pub struct Net {
     if_name: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Help)]
 pub struct NetParam {
+    /// MAC address of the virtual NIC, e.g. 06:3a:76:53:da:3d.
     pub mac: MacAddr,
+    /// Maximum transmission unit.
     pub mtu: u16,
+    /// Number of pairs of transmit/receive queues. [default: 1]
+    #[serde(alias = "qp")]
     pub queue_pairs: Option<NonZeroU16>,
+    /// Path to the character device file of a tap interface.
+    ///
+    /// Required for MacVTap and IPVTap, e.g. /dev/tapX.
+    /// Optional for TUN/TAP. [default: /dev/net/tun]
     pub tap: Option<PathBuf>,
+    /// Name of a tap interface, e.g. tapX.
+    ///
+    /// Required for TUN/TAP. Optional for MacVTap and IPVTap.
     #[serde(alias = "if")]
     pub if_name: Option<String>,
 }

--- a/alioth/src/virtio/dev/vsock/vhost_vsock.rs
+++ b/alioth/src/virtio/dev/vsock/vhost_vsock.rs
@@ -22,6 +22,7 @@ use libc::{eventfd, EFD_CLOEXEC, EFD_NONBLOCK};
 use mio::unix::SourceFd;
 use mio::{Interest, Registry, Token};
 use serde::Deserialize;
+use serde_aco::Help;
 
 use crate::ffi;
 use crate::mem::mapped::RamBus;
@@ -33,9 +34,11 @@ use crate::virtio::vhost::bindings::{VirtqAddr, VirtqFile, VirtqState, VHOST_FIL
 use crate::virtio::vhost::{error, UpdateVsockMem, VhostDev};
 use crate::virtio::{IrqSender, Result, VirtioFeature};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Help)]
 pub struct VhostVsockParam {
+    /// Vsock context id.
     pub cid: u32,
+    /// Path to the host device file. [default: /dev/vhost-vsock]
     pub dev: Option<PathBuf>,
 }
 

--- a/serde-aco-derive/Cargo.toml
+++ b/serde-aco-derive/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
-name = "alioth-macros"
-version.workspace = true
-edition.workspace = true
-description = "Proc macros for Alioth"
-repository.workspace = true
+name = "serde-aco-derive"
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+version.workspace = true
+edition.workspace = true
 
 [lib]
 proc-macro = true
@@ -13,3 +12,4 @@ proc-macro = true
 [dependencies]
 syn.workspace = true
 quote.workspace = true
+proc-macro2.workspace = true

--- a/serde-aco-derive/src/help.rs
+++ b/serde-aco-derive/src/help.rs
@@ -1,0 +1,247 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::iter::zip;
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::meta::ParseNestedMeta;
+use syn::punctuated::Punctuated;
+use syn::{
+    parse_macro_input, Attribute, Data, DataEnum, DataStruct, DeriveInput, Expr, ExprLit, Fields,
+    FieldsNamed, FieldsUnnamed, Ident, Lit, Meta, MetaNameValue, Token,
+};
+
+fn get_doc_from_attrs(attrs: &[Attribute]) -> String {
+    let mut lines = vec![];
+    for attr in attrs.iter() {
+        let Meta::NameValue(MetaNameValue {
+            path,
+            value: Expr::Lit(ExprLit {
+                lit: Lit::Str(s), ..
+            }),
+            ..
+        }) = &attr.meta
+        else {
+            continue;
+        };
+        if path.is_ident("doc") {
+            let v = s.value();
+            let mut trimmed = v.trim_end();
+            if let Some(t) = trimmed.strip_prefix(' ') {
+                trimmed = t;
+            }
+            if !trimmed.is_empty() {
+                lines.push(trimmed.to_string());
+            }
+        }
+    }
+    lines.join("\n")
+}
+
+fn get_serde_aliases_from_attrs(ident: &Ident, attrs: &[Attribute]) -> Vec<String> {
+    let mut aliases = vec![];
+    for attr in attrs.iter() {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        let Ok(nested) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        else {
+            continue;
+        };
+        for meta in nested {
+            let Meta::NameValue(MetaNameValue {
+                path,
+                value:
+                    Expr::Lit(ExprLit {
+                        lit: Lit::Str(s), ..
+                    }),
+                ..
+            }) = meta
+            else {
+                continue;
+            };
+            if !path.is_ident("alias") {
+                continue;
+            }
+            aliases.push(s.value());
+        }
+    }
+    aliases.push(ident.to_string());
+    aliases.sort_by(|l, r| {
+        if l.len() != r.len() {
+            l.len().cmp(&r.len())
+        } else {
+            for (a, b) in zip(l.chars(), r.chars()) {
+                if a == b {
+                    continue;
+                }
+                if a.is_lowercase() == b.is_lowercase() {
+                    return a.cmp(&b);
+                } else if a.is_lowercase() {
+                    return Ordering::Less;
+                } else {
+                    return Ordering::Greater;
+                }
+            }
+            Ordering::Equal
+        }
+    });
+    aliases
+}
+
+fn is_flattened(attrs: &[Attribute]) -> bool {
+    for attr in attrs.iter() {
+        if !attr.path().is_ident("serde_aco") {
+            continue;
+        }
+        let mut flattened = false;
+        let is_flatten = |meta: ParseNestedMeta| {
+            if meta.path.is_ident("flatten") {
+                flattened = true;
+            }
+            Ok(())
+        };
+        if attr.parse_nested_meta(is_flatten).is_err() {
+            continue;
+        }
+        if flattened {
+            return true;
+        }
+    }
+    false
+}
+
+fn derive_named_struct_help(name: &Ident, fields: &FieldsNamed) -> TokenStream2 {
+    let mut field_doc = vec![];
+    let mut flatten_fields = vec![];
+    for field in fields.named.iter() {
+        let ident = field.ident.as_ref().unwrap();
+        let aliases = get_serde_aliases_from_attrs(ident, &field.attrs);
+        let ident = &aliases[0];
+        let ty = &field.ty;
+        let doc = get_doc_from_attrs(&field.attrs);
+        let field_help = quote! {
+            FieldHelp {
+                ident: #ident,
+                doc: #doc,
+                ty: <#ty as Help>::help(),
+            }
+        };
+        if is_flattened(&field.attrs) {
+            flatten_fields.push(field_help);
+        } else {
+            field_doc.push(field_help);
+        }
+    }
+    if flatten_fields.is_empty() {
+        quote! {
+            TypedHelp::Struct{
+                name: stringify!(#name),
+                fields: vec![#(#field_doc,)*],
+            }
+        }
+    } else {
+        quote! {{
+            let mut fields = vec![#(#field_doc,)*];
+            let mut flatted_fields = vec![#(#flatten_fields,)*];
+            for mut field in flatted_fields {
+                match field.ty {
+                    TypedHelp::Enum { variants, .. } => field.ty = TypedHelp::FlattenedEnum { variants },
+                    TypedHelp::Option(mut o) => match *o {
+                        TypedHelp::Enum { variants, .. } => {
+                            *o = TypedHelp::FlattenedEnum { variants };
+                            field.ty = TypedHelp::Option(o);
+                        }
+                        _ => unreachable!(),
+                    },
+                    _ => unreachable!(),
+                };
+                fields.push(field);
+            }
+            TypedHelp::Struct{
+                name: stringify!(#name),
+                fields,
+            }
+        }}
+    }
+}
+
+fn derive_unnamed_struct_help(fields: &FieldsUnnamed) -> TokenStream2 {
+    if let Some(first) = fields.unnamed.first() {
+        let ty = &first.ty;
+        quote! { <#ty as Help>::help() }
+    } else if fields.unnamed.is_empty() {
+        quote! { TypedHelp::Unit }
+    } else {
+        panic!("Unnamed struct must have only one field")
+    }
+}
+
+fn derive_struct_help(name: &Ident, data: &DataStruct) -> TokenStream2 {
+    match &data.fields {
+        Fields::Named(fields) => derive_named_struct_help(name, fields),
+        Fields::Unnamed(fields) => derive_unnamed_struct_help(fields),
+        Fields::Unit => quote! { TypedHelp::Unit },
+    }
+}
+
+fn derive_enum_help(name: &Ident, data: &DataEnum) -> TokenStream2 {
+    let mut variants = vec![];
+    for variant in data.variants.iter() {
+        let doc = get_doc_from_attrs(&variant.attrs);
+        let ty = match &variant.fields {
+            Fields::Unit => quote! {TypedHelp::Unit},
+            Fields::Named(fields) => derive_named_struct_help(name, fields),
+            Fields::Unnamed(fields) => derive_unnamed_struct_help(fields),
+        };
+        let aliases = get_serde_aliases_from_attrs(&variant.ident, &variant.attrs);
+        let ident = &aliases[0];
+        variants.push(quote! {
+            FieldHelp {
+                ident: #ident,
+                doc: #doc,
+                ty: #ty,
+            }
+        })
+    }
+    quote! {
+        TypedHelp::Enum {
+            name: stringify!(#name),
+            variants: vec![#(#variants,)*],
+        }
+    }
+}
+
+pub fn derive_help(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ty_name = &input.ident;
+    let body = match &input.data {
+        Data::Struct(data) => derive_struct_help(ty_name, data),
+        Data::Enum(data) => derive_enum_help(ty_name, data),
+        Data::Union(_) => unimplemented!("Data::Union not supported"),
+    };
+    TokenStream::from(quote! {
+        const _:() = {
+            use ::serde_aco::{Help, TypedHelp, FieldHelp};
+            impl Help for #ty_name {
+                fn help() -> TypedHelp {
+                    #body
+                }
+            }
+        };
+    })
+}

--- a/serde-aco-derive/src/lib.rs
+++ b/serde-aco-derive/src/lib.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod de;
-mod error;
 mod help;
 
-pub use de::{from_arg, from_args, Deserializer};
-pub use error::{Error, Result};
-pub use help::{FieldHelp, Help, TypedHelp};
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(Help, attributes(serde_aco))]
+pub fn derive_help(input: TokenStream) -> TokenStream {
+    help::derive_help(input)
+}

--- a/serde-aco/Cargo.toml
+++ b/serde-aco/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 serde.workspace = true
+serde-aco-derive.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/serde-aco/src/help.rs
+++ b/serde-aco/src/help.rs
@@ -1,0 +1,93 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::{CStr, CString, OsStr, OsString};
+use std::num::NonZero;
+use std::path::{Path, PathBuf};
+
+pub use serde_aco_derive::Help;
+
+#[derive(Debug)]
+pub struct FieldHelp {
+    pub ident: &'static str,
+    pub doc: &'static str,
+    pub ty: TypedHelp,
+}
+
+#[derive(Debug)]
+pub enum TypedHelp {
+    Struct {
+        name: &'static str,
+        fields: Vec<FieldHelp>,
+    },
+    Enum {
+        name: &'static str,
+        variants: Vec<FieldHelp>,
+    },
+    FlattenedEnum {
+        variants: Vec<FieldHelp>,
+    },
+    String,
+    Int,
+    Float,
+    Bool,
+    Unit,
+    Custom {
+        desc: &'static str,
+    },
+    Option(Box<TypedHelp>),
+}
+
+pub trait Help {
+    fn help() -> TypedHelp;
+}
+
+macro_rules! impl_help_for_num_types {
+    ($help_type:ident, $($ty:ty),+) => {
+        $(impl Help for $ty {
+            fn help() -> TypedHelp {
+                TypedHelp::$help_type
+            }
+        })+
+        $(impl Help for NonZero<$ty> {
+            fn help() -> TypedHelp {
+                TypedHelp::$help_type
+            }
+        })+
+    };
+}
+
+macro_rules! impl_help_for_types {
+    ($help_type:ident, $($ty:ty),+) => {
+        $(impl Help for $ty {
+            fn help() -> TypedHelp {
+                TypedHelp::$help_type
+            }
+        })+
+    };
+}
+
+impl_help_for_num_types!(Int, i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
+impl_help_for_types!(Float, f32, f64);
+impl_help_for_types!(Bool, bool);
+impl_help_for_types!(String, &str, String, CStr, CString, &OsStr, OsString, &Path, PathBuf);
+
+impl<T> Help for Option<T>
+where
+    T: Help,
+{
+    fn help() -> TypedHelp {
+        TypedHelp::Option(Box::new(T::help()))
+    }
+}

--- a/serde-aco/src/help.rs
+++ b/serde-aco/src/help.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
@@ -90,4 +91,252 @@ where
     fn help() -> TypedHelp {
         TypedHelp::Option(Box::new(T::help()))
     }
+}
+
+#[derive(Debug, Default)]
+struct ExtraHelp<'a> {
+    types: HashSet<&'static str>,
+    helps: Vec<&'a TypedHelp>,
+}
+
+fn value_type(v: &TypedHelp) -> &'static str {
+    match v {
+        TypedHelp::Bool => "bool",
+        TypedHelp::Int => "integer",
+        TypedHelp::Float => "float",
+        TypedHelp::String => "string",
+        TypedHelp::Unit => todo!(),
+        TypedHelp::Custom { desc } => desc,
+        TypedHelp::Struct { name, .. } => name,
+        TypedHelp::Enum { name, .. } => name,
+        TypedHelp::Option(o) => value_type(o),
+        TypedHelp::FlattenedEnum { .. } => unreachable!(),
+    }
+}
+
+fn add_extra_help<'a>(extra: &mut ExtraHelp<'a>, v: &'a TypedHelp) {
+    let (TypedHelp::Enum {
+        name,
+        variants: fields,
+    }
+    | TypedHelp::Struct { name, fields }) = v
+    else {
+        return;
+    };
+    if extra.types.insert(name) {
+        extra.helps.push(v);
+        for f in fields {
+            add_extra_help(extra, &f.ty);
+        }
+    }
+}
+
+fn extra_help(s: &mut String, v: &TypedHelp) {
+    s.push_str("# ");
+    match v {
+        TypedHelp::Struct { name, fields } => {
+            struct_help(s, &mut None, name, fields, 2);
+        }
+        TypedHelp::Enum { name, variants } => {
+            enum_help(s, &mut None, name, variants, 2);
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn next_line(s: &mut String, indent: usize) {
+    s.push('\n');
+    for _ in 0..indent {
+        s.push(' ');
+    }
+}
+
+fn one_key_val<'a>(s: &mut String, extra: &mut Option<&mut ExtraHelp<'a>>, f: &'a FieldHelp) {
+    s.push_str(f.ident);
+    s.push_str("=<");
+    s.push_str(value_type(&f.ty));
+    s.push('>');
+    if let Some(extra) = extra {
+        add_extra_help(extra, &f.ty)
+    }
+}
+
+fn key_val_pairs<'a>(
+    s: &mut String,
+    extra: &mut Option<&mut ExtraHelp<'a>>,
+    variant: &str,
+    fields: &'a [FieldHelp],
+) {
+    let mut add_comma = false;
+    if !variant.is_empty() {
+        s.push_str(variant);
+        add_comma = true;
+    }
+    for f in fields.iter() {
+        let ty = if let TypedHelp::Option(b) = &f.ty {
+            b.as_ref()
+        } else {
+            &f.ty
+        };
+        if add_comma {
+            s.push(',');
+        } else {
+            add_comma = true;
+        }
+        if let TypedHelp::FlattenedEnum { variants } = ty {
+            s.push('(');
+            let mut need_separator = false;
+            for v in variants.iter() {
+                if need_separator {
+                    s.push('|');
+                } else {
+                    need_separator = true;
+                }
+                one_key_val(s, extra, v);
+            }
+            s.push(')');
+        } else {
+            one_key_val(s, extra, f);
+        }
+    }
+}
+
+fn value_helps(s: &mut String, indent: usize, width: usize, f: &FieldHelp) {
+    next_line(s, indent);
+    let mut first_line = true;
+    for line in f.doc.lines() {
+        if first_line {
+            s.push_str(&format!("- {:width$}\t{}", f.ident, line, width = width));
+            first_line = false;
+        } else {
+            next_line(s, indent + width + 2);
+            s.push('\t');
+            s.push_str(line);
+        }
+    }
+}
+
+fn field_helps(s: &mut String, indent: usize, fields: &[FieldHelp]) {
+    let field_len = |f: &FieldHelp| {
+        if let TypedHelp::FlattenedEnum { variants } = &f.ty {
+            variants.iter().map(|v| v.ident.len()).max().unwrap_or(0)
+        } else {
+            f.ident.len()
+        }
+    };
+    let Some(width) = fields.iter().map(field_len).max() else {
+        return;
+    };
+    for f in fields.iter() {
+        if f.doc.is_empty() {
+            continue;
+        }
+        if let TypedHelp::FlattenedEnum { variants } = &f.ty {
+            for v in variants {
+                value_helps(s, indent, width, v);
+            }
+        } else {
+            value_helps(s, indent, width, f);
+        }
+    }
+}
+
+fn struct_help<'a>(
+    s: &mut String,
+    extra: &mut Option<&mut ExtraHelp<'a>>,
+    desc: &str,
+    fields: &'a [FieldHelp],
+    indent: usize,
+) {
+    s.push_str(desc);
+    next_line(s, indent);
+    s.push_str("* ");
+    key_val_pairs(s, extra, "", fields);
+    field_helps(s, indent + 2, fields);
+}
+
+fn enum_all_unit_help(s: &mut String, variants: &[FieldHelp], indent: usize) -> bool {
+    if variants.iter().any(|f| !matches!(f.ty, TypedHelp::Unit)) {
+        return false;
+    }
+    let Some(width) = variants.iter().map(|f| f.ident.len()).max() else {
+        return false;
+    };
+    for variant in variants.iter() {
+        next_line(s, indent);
+        s.push_str(&format!(
+            "* {:width$}\t{}",
+            variant.ident,
+            variant.doc,
+            width = width
+        ));
+    }
+    true
+}
+
+fn enum_help<'a>(
+    s: &mut String,
+    extra: &mut Option<&mut ExtraHelp<'a>>,
+    doc: &str,
+    variants: &'a [FieldHelp],
+    indent: usize,
+) {
+    s.push_str(doc);
+    if enum_all_unit_help(s, variants, indent) {
+        return;
+    }
+    if variants.is_empty() {
+        next_line(s, indent);
+        s.push_str("No options available");
+    }
+    for variant in variants.iter() {
+        next_line(s, indent);
+        s.push_str("* ");
+        match &variant.ty {
+            TypedHelp::Struct { fields, .. } => {
+                key_val_pairs(s, extra, variant.ident, fields);
+                next_line(s, indent + 2);
+                s.push_str(variant.doc);
+                field_helps(s, indent + 2, fields);
+            }
+            TypedHelp::Unit => {
+                s.push_str(variant.ident);
+                next_line(s, indent + 2);
+                s.push_str(variant.doc);
+            }
+            TypedHelp::String
+            | TypedHelp::Int
+            | TypedHelp::Float
+            | TypedHelp::Bool
+            | TypedHelp::Custom { .. } => {
+                s.push_str(variant.ident);
+                s.push_str(",<");
+                s.push_str(value_type(&variant.ty));
+                s.push('>');
+                next_line(s, indent + 2);
+                s.push_str(variant.doc);
+            }
+            _ => todo!("{:?}", variant.ty),
+        };
+    }
+}
+
+pub fn help_text<T: Help>(doc: &str) -> String {
+    let help = T::help();
+    let mut s = String::new();
+    let mut extra = ExtraHelp::default();
+    match &help {
+        TypedHelp::Struct { fields, .. } => {
+            struct_help(&mut s, &mut Some(&mut extra), doc, fields, 0);
+        }
+        TypedHelp::Enum { variants, .. } => {
+            enum_help(&mut s, &mut Some(&mut extra), doc, variants, 0)
+        }
+        _ => unreachable!("{:?}", help),
+    }
+    for h in extra.helps {
+        next_line(&mut s, 0);
+        extra_help(&mut s, h);
+    }
+    s
 }

--- a/serde-aco/src/lib.rs
+++ b/serde-aco/src/lib.rs
@@ -18,4 +18,4 @@ mod help;
 
 pub use de::{from_arg, from_args, Deserializer};
 pub use error::{Error, Result};
-pub use help::{FieldHelp, Help, TypedHelp};
+pub use help::{help_text, FieldHelp, Help, TypedHelp};


### PR DESCRIPTION
Trait `Help` returns a description of a type. It is used to generate the help message for the command line interface.

The derive macro implements `Help` for enums and structs and includes inline documentation in the description.

`help_text` generates the help message at runtime. It cannot be done at compile time because proc macro cannot access the information of sub-field types.

Now `alioth run --help` gives help message for flags, for example:
```text
  -m, --memory <MEMORY>      Specify the memory of the guest.
                             * size=<integer>,backend=<MemBackend>,shared=<bool>,thp=<bool>
                               - size           Total guest memory size in bytes. [default: 1G]
                               - backend        Host backend, [default: anon]
                               - shared         mmap() guest memory with MAP_SHARED or MAP_PRIVATE.
                                                [default: false]
                               - thp            Enable transparent hugepage. [default: false]
                             # MemBackend
                               * anon   Anonymous memory by MAP_ANONYMOUS.
                               * memfd  Anonymous file by memfd_create(). Always uses MAP_SHARED.

```