### PR TITLE
doc(cli): fix the example in `--object` help

### DIFF
--- a/alioth-cli/src/main.rs
+++ b/alioth-cli/src/main.rs
@@ -124,7 +124,7 @@ vhost-user process listening on socket `/path/to/socket=1`, these
 2 devices can be expressed in the command line as follows:
     --blk path=id_blk --fs vu,socket=id_fs,tag=shared-dir \
     -o id_blk,/path/to/disk,2024.img \
-    -o id_fs,socket=/path/to/socket=1"#;
+    -o id_fs,/path/to/socket=1"#;
 
 #[derive(Args, Debug, Clone)]
 #[command(arg_required_else_help = true)]


### PR DESCRIPTION
Fixes: 6381397d5657 ("doc(cli): add help message to the flag --object")