### PR TITLE
fix(aco)!: report an error if an id is not found

### DIFF
--- a/serde-aco/src/error.rs
+++ b/serde-aco/src/error.rs
@@ -26,6 +26,7 @@ pub enum Error {
     ExpectedUnit,
     Trailing(String),
     Ignored(String),
+    IdNotFound(String),
     Overflow,
     UnknownType,
 }


### PR DESCRIPTION
If an id is not found, it is more likely to be a typo than a value which is serialized to `id_xxxx`. If the later case really happens, the value can still be represented by the id_ syntax.