### PR TITLE
fix(kvm): calculate correct mask for 64bit MMIO

### DIFF
--- a/alioth/src/hv/kvm/vmexit.rs
+++ b/alioth/src/hv/kvm/vmexit.rs
@@ -23,8 +23,7 @@ impl KvmVcpu {
     #[cfg(target_endian = "little")]
     pub(super) fn handle_mmio(&mut self) -> Result<VmExit, Error> {
         let kvm_mmio = unsafe { &self.kvm_run.exit.mmio };
-        let data = u64::from_ne_bytes(kvm_mmio.data)
-            & 1u64.wrapping_shl(kvm_mmio.len << 3).wrapping_sub(1);
+        let data = u64::from_ne_bytes(kvm_mmio.data) & u64::MAX >> (64 - (kvm_mmio.len << 3));
         let exit = VmExit::Mmio {
             addr: kvm_mmio.phys_addr,
             write: if kvm_mmio.is_write > 0 {


### PR DESCRIPTION
1u64.wrapping_shl(64) returns 1 instead of 0. Without the fix, for 64bit MMIO, the mask is 0 instead of u64::MAX.

Fixes: c988169b2758 ("fix(kvm): clear the high part of mmio write values")