### PR TITLE
Revert "fix(virtio): monitor eventfds with IORING_OP_POLL_ADD"

### DIFF
--- a/alioth/src/virtio/dev/dev.rs
+++ b/alioth/src/virtio/dev/dev.rs
@@ -233,6 +233,7 @@ pub trait Backend<D: Virtio>: Send + 'static {
     type Data<'m>;
 
     fn register_waker(&mut self, token: u64) -> Result<Arc<Waker>>;
+    fn reregister_waker(&mut self, data: &mut Self::Data<'_>) -> Result<()>;
     fn activate_dev(
         &mut self,
         dev: &mut D,
@@ -308,6 +309,9 @@ where
                     break;
                 }
             }
+        }
+        if self.state == WorkerState::Running {
+            backend.reregister_waker(data)?;
         }
         Ok(())
     }

--- a/alioth/src/virtio/worker/io_uring.rs
+++ b/alioth/src/virtio/worker/io_uring.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::os::fd::AsRawFd;
 use std::sync::mpsc::Receiver;
@@ -62,6 +63,7 @@ const TOKEN_QUEUE: u64 = 1 << 62;
 const TOKEN_DESCRIPTOR: u64 = 1 << 62 | 1 << 61;
 
 pub struct IoUring<E> {
+    efd_buffer: UnsafeCell<u64>,
     queue_ioeventfds: Arc<[(E, bool)]>,
     queue_submits: Box<[QueueSubmit]>,
     waker: Arc<Waker>,
@@ -75,16 +77,16 @@ where
     fn submit_queue_ioeventfd(&self, index: u16, fd: &E, data: &mut RingData) -> Result<()> {
         let token = index as u64 | TOKEN_QUEUE;
         let fd = types::Fd(fd.as_fd().as_raw_fd());
-        let poll = opcode::PollAdd::new(fd, libc::EPOLLIN as _);
-        let entry = poll.build().user_data(token);
+        let read = opcode::Read::new(fd, self.efd_buffer.get() as *mut u8, 8);
+        let entry = read.build().user_data(token);
         unsafe { data.ring.submission().push(&entry) }.unwrap();
         Ok(())
     }
 
     fn submit_waker(&mut self, data: &mut RingData) -> Result<()> {
         let fd = types::Fd(self.waker.0.as_raw_fd());
-        let poll = opcode::PollAdd::new(fd, libc::EPOLLIN as _).multi(true);
-        let entry = poll.build().user_data(self.waker_token);
+        let read = opcode::Read::new(fd, self.efd_buffer.get() as *mut u8, 8);
+        let entry = read.build().user_data(self.waker_token);
         unsafe { data.ring.submission().push(&entry) }.unwrap();
         Ok(())
     }
@@ -103,6 +105,7 @@ where
     {
         let waker = Waker::new_eventfd()?;
         let ring = IoUring {
+            efd_buffer: UnsafeCell::new(0),
             queue_ioeventfds: fds,
             waker: Arc::new(waker),
             waker_token: 0,
@@ -196,6 +199,10 @@ where
     fn register_waker(&mut self, token: u64) -> Result<Arc<Waker>> {
         self.waker_token = token;
         Ok(self.waker.clone())
+    }
+
+    fn reregister_waker(&mut self, data: &mut RingData<'_>) -> Result<()> {
+        self.submit_waker(data)
     }
 
     fn activate_dev(

--- a/alioth/src/virtio/worker/mio.rs
+++ b/alioth/src/virtio/worker/mio.rs
@@ -137,6 +137,10 @@ where
         }
     }
 
+    fn reregister_waker(&mut self, _data: &mut ()) -> Result<()> {
+        Ok(())
+    }
+
     fn activate_dev(
         &mut self,
         dev: &mut D,


### PR DESCRIPTION
This reverts commit 0c4fc4e3ba8e12752d6652810029e5bb4ab6bc97.

It causes 100% CPU usage while io_uring is enabled.