### PR TITLE
refactor(pci): add a constructor for EmulatedHeader

### DIFF
--- a/alioth/src/device/pvpanic.rs
+++ b/alioth/src/device/pvpanic.rs
@@ -74,14 +74,13 @@ impl PvPanic {
             bars: [BAR_MEM64 | BAR_PREFETCHABLE, 0, 0, 0, 0, 0],
             ..Default::default()
         };
-        let bar_masks = [!(BAR_SIZE as u32 - 1), 0xffff_ffff, 0, 0, 0, 0];
         let bar0 = PciBar::Mem(Arc::new(MemRegion::with_emulated(
             Arc::new(PvPanicBar::<BAR_SIZE>),
             mem::MemRegionType::Hidden,
         )));
         let mut bars = [const { PciBar::Empty }; 6];
         bars[0] = bar0;
-        let config = EmulatedConfig::new_device(header, bar_masks, bars, PciCapList::new());
+        let config = EmulatedConfig::new_device(header, bars, PciCapList::new());
         PvPanic { config }
     }
 }

--- a/alioth/src/pci/config_test.rs
+++ b/alioth/src/pci/config_test.rs
@@ -1,0 +1,71 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::mem::emulated::{Action, Mmio};
+use crate::mem::{self, IoRegion, MemRegion, MemRegionType};
+use crate::pci::PciBar;
+use crate::pci::config::{
+    BAR_IO, BAR_MEM32, BAR_MEM64, ConfigHeader, DeviceHeader, EmulatedHeader,
+};
+
+#[derive(Debug)]
+struct TestRange {
+    size: u64,
+}
+
+impl Mmio for TestRange {
+    fn read(&self, _: u64, _: u8) -> mem::Result<u64> {
+        Ok(0)
+    }
+
+    fn write(&self, _: u64, _: u8, _: u64) -> mem::Result<Action> {
+        Ok(Action::None)
+    }
+
+    fn size(&self) -> u64 {
+        self.size
+    }
+}
+
+#[test]
+fn test_emulated_header() {
+    let header = ConfigHeader::Device(DeviceHeader {
+        bars: [BAR_MEM32, 0, BAR_MEM64, 0, 0, BAR_IO],
+        ..Default::default()
+    });
+    let bars = [
+        PciBar::Mem(Arc::new(MemRegion::with_emulated(
+            Arc::new(TestRange { size: 1 << 10 }),
+            MemRegionType::Hidden,
+        ))),
+        PciBar::Empty,
+        PciBar::Mem(Arc::new(MemRegion::with_emulated(
+            Arc::new(TestRange { size: 16 << 10 }),
+            MemRegionType::Hidden,
+        ))),
+        PciBar::Empty,
+        PciBar::Empty,
+        PciBar::Io(Arc::new(IoRegion::new(Arc::new(TestRange { size: 2 })))),
+    ];
+
+    let emulated_header = EmulatedHeader::new(header, bars);
+
+    let data = emulated_header.data.read();
+    assert_eq!(
+        data.bar_masks,
+        [0xffff_f000, 0x0, 0xffff_c000, 0xffff_ffff, 0x0, 0xffff_fffc,]
+    );
+}

--- a/alioth/src/pci/host_bridge.rs
+++ b/alioth/src/pci/host_bridge.rs
@@ -46,7 +46,7 @@ impl HostBridge {
             ..Default::default()
         };
         let bars = [const { PciBar::Empty }; 6];
-        let config = EmulatedConfig::new_device(header, [0; 6], bars, PciCapList::new());
+        let config = EmulatedConfig::new_device(header, bars, PciCapList::new());
         HostBridge { config }
     }
 }

--- a/alioth/src/virtio/pci.rs
+++ b/alioth/src/virtio/pci.rs
@@ -881,20 +881,16 @@ where
             bar0.ranges.push(MemRange::Emulated(device_config))
         }
         let mut bars = [const { PciBar::Empty }; 6];
-        let mut bar_masks = [0; 6];
-        let bar0_mask = !(bar0_size - 1);
-        bar_masks[0] = bar0_mask as u32;
+
         bars[0] = PciBar::Mem(Arc::new(bar0));
         header.bars[0] = BAR_MEM32;
 
         if let Some(region) = &dev.shared_mem_regions {
             let region_size = region.size();
-            let bar2_mask = !(region_size.next_power_of_two() - 1);
-            bar_masks[2] = bar2_mask as u32;
+
             let mut not_emulated = |r| !matches!(r, &MemRange::Emulated(_));
             let prefetchable = region.ranges.iter().all(&mut not_emulated);
             if prefetchable {
-                bar_masks[3] = (bar2_mask >> 32) as u32;
                 bars[2] = PciBar::Mem(region.clone());
                 header.bars[2] = BAR_MEM64 | BAR_PREFETCHABLE;
             } else {
@@ -904,7 +900,7 @@ where
             }
         }
 
-        let config = EmulatedConfig::new_device(header, bar_masks, bars, cap_list);
+        let config = EmulatedConfig::new_device(header, bars, cap_list);
 
         Ok(VirtioPciDevice {
             dev,


### PR DESCRIPTION
BAR masks can also be calculated in the constructor universally.