### PR TITLE
fix(dt): preserve device tree node order

### DIFF
--- a/alioth/src/firmware/dt/dt.rs
+++ b/alioth/src/firmware/dt/dt.rs
@@ -50,7 +50,7 @@ impl PropVal {
 #[derive(Debug, Clone, Default)]
 pub struct Node {
     pub props: HashMap<&'static str, PropVal>,
-    pub nodes: HashMap<String, Node>,
+    pub nodes: Vec<(String, Node)>,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
Linux assigns indexes to CPUs based on the order of the corresponding CPU nodes in the devicetree. Using a HashMap for sub-nodes does not guarantee any order.

To ensure the flattened devicetree has the same sub-node order as the CPU nodes are created, this commit changes the representation of devicetree sub-nodes from a HashMap to a Vec of key-value pairs.