### PR TITLE
fix(blk): add file lock to disk image

### DIFF
--- a/alioth/src/virtio/dev/blk.rs
+++ b/alioth/src/virtio/dev/blk.rs
@@ -198,6 +198,16 @@ impl Block {
             .write(!param.readonly)
             .open(&param.path)
             .context(access_disk)?;
+
+        let ctx_lock = error::LockFile {
+            path: param.path.as_ref(),
+        };
+        if param.readonly {
+            disk.try_lock_shared().context(ctx_lock)
+        } else {
+            disk.try_lock().context(ctx_lock)
+        }?;
+
         let len = disk.metadata().context(access_disk)?.len();
         let config = BlockConfig {
             capacity: len / SECTOR_SIZE as u64,

--- a/alioth/src/virtio/virtio.rs
+++ b/alioth/src/virtio/virtio.rs
@@ -49,6 +49,11 @@ pub enum Error {
         path: Box<Path>,
         error: std::io::Error,
     },
+    #[snafu(display("Failed to lock file {path:?}"))]
+    LockFile {
+        path: Box<Path>,
+        error: std::fs::TryLockError,
+    },
     #[snafu(display("Error from OS"), context(false))]
     System { error: std::io::Error },
     #[snafu(display("Failed to create a poll"))]


### PR DESCRIPTION
Introduce file locking for the virtio block device's disk image to prevent multiple processes or VMs from accessing the same disk image concurrently, which could lead to data corruption.

A shared lock is used for read-only access, and an exclusive lock for read-write access.