### PR TITLE
fix(vsock): set guest-initiated connections to non-blocking

### DIFF
--- a/alioth/src/virtio/dev/vsock/uds_vsock.rs
+++ b/alioth/src/virtio/dev/vsock/uds_vsock.rs
@@ -371,6 +371,7 @@ impl UdsVsock {
                 return self.respond_rst(hdr, irq_sender, rx_q);
             }
         };
+        reader.set_nonblocking(true)?;
         let writer = reader.try_clone()?;
         let token = Token(reader.as_raw_fd() as usize);
         registry.register(

--- a/alioth/src/virtio/dev/vsock/uds_vsock_test.rs
+++ b/alioth/src/virtio/dev/vsock/uds_vsock_test.rs
@@ -243,7 +243,14 @@ fn vsock_conn_test(fixture_ram_bus: RamBus, #[with(3)] fixture_queues: Box<[Queu
 
     // 1. Host to Guest via guest-initiated connection
     let h2g_data = "hello from host";
-    let buf_id = rx_q.add_desc(&[], &[(rx_buf_addr, 4096)]);
+    let buf_id = rx_q.add_desc(
+        &[],
+        &[
+            (rx_buf_addr, 32),
+            (rx_buf_addr + 32, 32),
+            (rx_buf_addr + 64, 32),
+        ],
+    );
     tx.send(WakeEvent::Notify {
         q_index: VsockVirtq::RX.raw(),
     })


### PR DESCRIPTION
In guest-initiated connections, the Unix stream socket was created in blocking mode. This caused the `uds_vsock` worker to block indefinitely when reading from the socket if the RX queue had available buffers but the host had not sent enough data to fill them.

The test is also updated to use multiple buffers in the RX queue to reproduce and verify the fix.