### PR TITLE
ci: restrict Rust workflow to relevant paths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,12 +5,14 @@ permissions: read-all
 on:
   push:
     branches: ["main"]
-    paths-ignore:
-      - 'bootloader/**'
+    paths: &on_paths
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - Cargo.lock
+      - .github/workflows/rust.yml
   pull_request:
     branches: ["main"]
-    paths-ignore:
-      - 'bootloader/**'
+    paths: *on_paths
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This prevents the workflow from running on irrelevant changes, such as to documentation or non-Rust code.