### PR TITLE
fix(dt): remove msi-parent property from PCI bridge node

### DIFF
--- a/alioth/src/board/board_aarch64.rs
+++ b/alioth/src/board/board_aarch64.rs
@@ -516,7 +516,6 @@ where
                     // Documentation/devicetree/bindings/pci/pci-msi.txt
                     PropVal::U32List(vec![0, PHANDLE_MSI, 0, 0x10000]),
                 ),
-                ("msi-parent", PropVal::PHandle(PHANDLE_MSI)),
             ]),
             nodes: Vec::new(),
         };


### PR DESCRIPTION
The `msi-parent` property was triggering a guest kernel warning because the kernel expects a DeviceID after the property's phandle:

[    0.199453] OF: /pci@30000000: #msi-cells = 1 found 0

This property is not required for `pci-host-ecam-generic`. Removing it resolves the warning.