### PR TITLE
fix(net): remove INDIRECT_DESC from feature set

### DIFF
--- a/alioth/src/virtio/dev/net/net.rs
+++ b/alioth/src/virtio/dev/net/net.rs
@@ -112,7 +112,6 @@ bitflags! {
         const RSC_EXT = 1 << 61;
         const STANDBY = 1 << 62;
         const SPEED_DUPLEX = 1 << 63;
-        const INDIRECT_DESC = 1 << 28;
     }
 }
 


### PR DESCRIPTION
INDIRECT_DESC is a virtio queue feature.

Fixes: e2f11df3475a ("fix(virtio): devices return the full feature sets")