### PR TITLE
build(bootloader): use go.mod to vendor u-root commands

### DIFF
--- a/bootloader/initramfs/go.mod
+++ b/bootloader/initramfs/go.mod
@@ -2,13 +2,15 @@ module initramfs
 
 go 1.24.8
 
-require github.com/u-root/u-root v0.15.0
+require github.com/u-root/u-root v0.15.0 // indirect
 
 require (
+	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc // indirect
 	github.com/therootcompany/xz v1.0.1 // indirect
 	github.com/u-root/cpuid v0.0.1-0.20250320140348-cc5fe81d966c // indirect
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
@@ -18,4 +20,10 @@ require (
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
+	pack.ag/tftp v1.0.1-0.20181129014014-07909dfbde3c // indirect
+)
+
+tool (
+	github.com/u-root/u-root/cmds/boot/boot
+	github.com/u-root/u-root/cmds/core/init
 )

--- a/bootloader/initramfs/initramfs.go
+++ b/bootloader/initramfs/initramfs.go
@@ -1,9 +1,0 @@
-//go:build tools
-
-package initramfs
-
-import (
-	_ "github.com/u-root/u-root/pkg/boot"
-	_ "github.com/u-root/u-root/pkg/boot/menu"
-	_ "github.com/u-root/u-root/pkg/libinit"
-)


### PR DESCRIPTION
Use the 'tool' directive in go.mod to specify the required u-root commands, replacing the now-deleted initramfs.go file. This is a more idiomatic way to ensure reproducible builds with consistent tool versions.