### PR TITLE
ci(rust): remove unnecessary caches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,16 +36,10 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ~/.rustup/settings.toml
-            ~/.rustup/toolchains/
-            ~/.rustup/update-hashes/
             target/
-            target/tarpaulin/
           key: ${{ matrix.target.name }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
Remove the ~/.rustup cache, as caching the toolchain is ineffective.

Remove tarpaulin-related caches introduced in d49daec05b82 ("ci: collect and upload test coverage"), as tarpaulin is no longer used for collecting test coverage.