### PR TITLE
refactor: introduce custom bitflags! macro

### DIFF
--- a/alioth/src/arch/aarch64/reg.rs
+++ b/alioth/src/arch/aarch64/reg.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use bitfield::bitfield;
-use bitflags::bitflags;
 
-use crate::consts;
+use crate::{bitflags, consts};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Reg {
@@ -82,33 +81,32 @@ consts! {
 
 // https://developer.arm.com/documentation/den0024/a/ARMv8-Registers/Processor-state
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Pstate: u32 {
+    pub struct Pstate(u32) {
         /// Negative condition flag.
-        const N = 1 << 31;
+        N = 1 << 31;
         /// Zero condition flag.
-        const Z = 1 << 30;
+        Z = 1 << 30;
         /// Carry condition flag.
-        const C = 1 << 29;
+        C = 1 << 29;
         /// oVerflow condition flag.
-        const V = 1 << 28;
+        V = 1 << 28;
         /// Debug mask bit.
         /// Software Step bit.
-        const SS = 1 << 21;
+        SS = 1 << 21;
         /// Illegal execution state bit.
-        const IL = 1 << 20;
-        const D = 1 << 9;
+        IL = 1 << 20;
+        D = 1 << 9;
         /// SError mask bit.
-        const A = 1 << 8;
+        A = 1 << 8;
         /// IRQ mask bit.
-        const I = 1 << 7;
+        I = 1 << 7;
         /// FIQ mask bit.
-        const F = 1 << 6;
-        const M = 1 << 4;
+        F = 1 << 6;
+        M = 1 << 4;
 
-        const EL_BIT3 = 1 << 3;
-        const EL_BIT2 = 1 << 2;
-        const EL_H = 1 << 0;
+        EL_BIT3 = 1 << 3;
+        EL_BIT2 = 1 << 2;
+        EL_H = 1 << 0;
     }
 }
 

--- a/alioth/src/arch/x86_64/msr.rs
+++ b/alioth/src/arch/x86_64/msr.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use bitfield::bitfield;
-use bitflags::bitflags;
+
+use crate::bitflags;
 
 // Intel Vol.4, Table 2-2.
 pub const IA32_EFER: u32 = 0xc000_0080;
@@ -28,24 +29,22 @@ pub const IA32_TSC_AUX: u32 = 0xc000_0103;
 pub const IA32_MISC_ENABLE: u32 = 0x0000_01a0;
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Efer: u32 {
+    pub struct Efer(u32) {
         /// SYSCALL enable
-        const SCE = 1 << 0;
+        SCE = 1 << 0;
         /// IA-32e mode enable
-        const LME = 1 << 8;
+        LME = 1 << 8;
         /// IA-32e mode active
-        const LMA = 1 << 10;
+        LMA = 1 << 10;
         /// Execute disable bit enable
-        const NXE = 1 << 11;
+        NXE = 1 << 11;
     }
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct MiscEnable: u64 {
+    pub struct MiscEnable(u64) {
         /// Enable Fast-Strings
-        const FAST_STRINGS = 1 << 0;
+        FAST_STRINGS = 1 << 0;
     }
 }
 

--- a/alioth/src/arch/x86_64/paging.rs
+++ b/alioth/src/arch/x86_64/paging.rs
@@ -12,28 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bitflags::bitflags;
+use crate::bitflags;
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Entry: u32 {
+    pub struct Entry(u32) {
         /// Present
-        const P = 1 << 0;
+        P = 1 << 0;
         /// Read/write
-        const RW = 1 << 1;
+        RW = 1 << 1;
         /// User/supervisor
-        const US = 1 << 2;
+        US = 1 << 2;
         /// Page-level write-through
-        const PWT = 1 << 3;
+        PWT = 1 << 3;
         /// Page-level cache disable
-        const PCD = 1 << 4;
+        PCD = 1 << 4;
         /// Accessed
-        const A = 1 << 5;
+        A = 1 << 5;
         /// Dirty
-        const D = 1 << 6;
+        D = 1 << 6;
         /// Page size
-        const PS = 1 << 7;
+        PS = 1 << 7;
         /// Global
-        const G = 1 << 8;
+        G = 1 << 8;
     }
 }

--- a/alioth/src/arch/x86_64/reg.rs
+++ b/alioth/src/arch/x86_64/reg.rs
@@ -13,141 +13,138 @@
 // limitations under the License.
 
 use bitfield::bitfield;
-use bitflags::bitflags;
+
+use crate::bitflags;
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Rflags: u32 {
+    pub struct Rflags(u32) {
         /// CarryCarry flag
-        const CF = 1 << 0;
+        CF = 1 << 0;
         /// CarryReserved
-        const RESERVED_1 = 1 << 1;
+        RESERVED_1 = 1 << 1;
         /// CarryParity flag
-        const PF = 1 << 2;
+        PF = 1 << 2;
         /// CarryAuxiliary Carry flag
-        const AF = 1 << 4;
+        AF = 1 << 4;
         /// CarryZero flag
-        const ZF = 1 << 6;
+        ZF = 1 << 6;
         /// CarrySign flag
-        const SF = 1 << 7;
+        SF = 1 << 7;
         /// CarryTrap flag
-        const TF = 1 << 8;
+        TF = 1 << 8;
         /// CarryInterrupt enable flag
-        const IF = 1 << 9;
+        IF = 1 << 9;
         /// CarryDirection flag
-        const DF = 1 << 10;
+        DF = 1 << 10;
         /// CarryOverflow flag
-        const OF = 1 << 11;
+        OF = 1 << 11;
         /// CarryI/O privilege level
-        const IOPL = 1 << 13;
+        IOPL = 1 << 13;
         /// CarryNested task flag
-        const NT = 1 << 14;
+        NT = 1 << 14;
         /// CarryResume flag
-        const RF = 1 << 16;
+        RF = 1 << 16;
         /// CarryVirtual 8086 mode flag
-        const VM = 1 << 17;
+        VM = 1 << 17;
         /// CarryAlignment Check
-        const AC = 1 << 18;
+        AC = 1 << 18;
         /// CarryVirtual interrupt flag
-        const VIF = 1 << 19;
+        VIF = 1 << 19;
         /// CarryVirtual interrupt pending
-        const VIP = 1 << 20;
+        VIP = 1 << 20;
         /// CarryIdentification flag
-        const ID = 1 << 21;
+        ID = 1 << 21;
     }
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Cr0: u32 {
+    pub struct Cr0(u32) {
         /// CarryProtected Mode Enable
-        const PE = 1 << 0;
+        PE = 1 << 0;
         /// CarryMonitor co-processor
-        const MP = 1 << 1;
+        MP = 1 << 1;
         /// CarryEmulation
-        const EM = 1 << 2;
+        EM = 1 << 2;
         /// CarryTask switched
-        const TS = 1 << 3;
+        TS = 1 << 3;
         /// CarryExtension type
-        const ET = 1 << 4;
+        ET = 1 << 4;
         /// CarryNumeric error
-        const NE = 1 << 5;
+        NE = 1 << 5;
         /// CarryWrite protect
-        const WP = 1 << 16;
+        WP = 1 << 16;
         /// CarryAlignment mask
-        const AM = 1 << 18;
+        AM = 1 << 18;
         /// CarryNot-write through
-        const NW = 1 << 29;
+        NW = 1 << 29;
         /// CarryCache disable
-        const CD = 1 << 30;
+        CD = 1 << 30;
         /// CarryPaging
-        const PG = 1 << 31;
+        PG = 1 << 31;
     }
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Cr3: u64 {
+    pub struct Cr3(u64) {
         /// CarryPage-level write-through
-        const PWT = 1 << 3;
+        PWT = 1 << 3;
         /// CarryPage-level Cache disable
-        const PCD = 1 << 4;
+        PCD = 1 << 4;
     }
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Cr4: u32 {
+    pub struct Cr4(u32) {
         /// CarryVirtual 8086 Mode Extensions
-        const VME = 1 << 0;
+        VME = 1 << 0;
         /// CarryProtected-mode Virtual Interrupts
-        const PVI = 1 << 1;
+        PVI = 1 << 1;
         /// CarryTime Stamp Disable
-        const TSD = 1 << 2;
+        TSD = 1 << 2;
         /// CarryDebugging Extensions
-        const DE = 1 << 3;
+        DE = 1 << 3;
         /// CarryPage Size Extension
-        const PSE = 1 << 4;
+        PSE = 1 << 4;
         /// CarryPhysical Address Extension
-        const PAE = 1 << 5;
+        PAE = 1 << 5;
         /// CarryMachine Check Exception
-        const MCE = 1 << 6;
+        MCE = 1 << 6;
         /// CarryPage Global Enabled
-        const PGE = 1 << 7;
+        PGE = 1 << 7;
         /// CarryPerformance-Monitoring Counter enable
-        const PCE = 1 << 8;
+        PCE = 1 << 8;
         /// CarryOperating system support for FXSAVE and FXRSTOR instructions
-        const OSFXSR = 1 << 9;
+        OSFXSR = 1 << 9;
         /// CarryOperating System Support for Unmasked SIMD Floating-Point Exceptions
-        const OSXMMEXCPT = 1 << 10;
+        OSXMMEXCPT = 1 << 10;
         /// CarryUser-Mode Instruction Prevention
-        const UMIP = 1 << 11;
+        UMIP = 1 << 11;
         /// Carry57-Bit Linear Addresses
-        const LA57 = 1 << 12;
+        LA57 = 1 << 12;
         /// CarryVirtual Machine Extensions Enable
-        const VMXE = 1 << 13;
+        VMXE = 1 << 13;
         /// CarrySafer Mode Extensions Enable
-        const SMXE = 1 << 14;
+        SMXE = 1 << 14;
         /// CarryFSGSBASE Enable
-        const FSGSBASE = 1 << 16;
+        FSGSBASE = 1 << 16;
         /// CarryPCID Enable
-        const PCIDE = 1 << 17;
+        PCIDE = 1 << 17;
         /// CarryXSAVE and Processor Extended States Enable
-        const OSXSAVE = 1 << 18;
+        OSXSAVE = 1 << 18;
         /// CarryKey Locker Enable
-        const KL = 1 << 19;
+        KL = 1 << 19;
         /// CarrySupervisor Mode Execution Protection Enable
-        const SMEP = 1 << 20;
+        SMEP = 1 << 20;
         /// CarrySupervisor Mode Access Prevention Enable
-        const SMAP = 1 << 21;
+        SMAP = 1 << 21;
         /// CarryProtection Key Enable
-        const PKE = 1 << 22;
+        PKE = 1 << 22;
         /// CarryControl-flow Enforcement Technology
-        const CET = 1 << 23;
+        CET = 1 << 23;
         /// CarryEnable Protection Keys for Supervisor-Mode Pages
-        const PKS = 1 << 24;
+        PKS = 1 << 24;
         /// CarryUser Interrupts Enable
-        const UINTR = 1 << 25;
+        UINTR = 1 << 25;
     }
 }
 

--- a/alioth/src/arch/x86_64/tdx.rs
+++ b/alioth/src/arch/x86_64/tdx.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bitflags::bitflags;
+use crate::bitflags;
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct TdAttr: u64 {
-        const DEBUG = 1 << 0;
-        const SEPT_VE_DISABLE = 1 << 28;
-        const PKS = 1 << 30;
-        const PERFMON = 1 << 63;
+    pub struct TdAttr(u64) {
+        DEBUG = 1 << 0;
+        SEPT_VE_DISABLE = 1 << 28;
+        PKS = 1 << 30;
+        PERFMON = 1 << 63;
     }
 }

--- a/alioth/src/blk/qcow2.rs
+++ b/alioth/src/blk/qcow2.rs
@@ -14,11 +14,10 @@
 
 use alioth_macros::Layout;
 use bitfield::bitfield;
-use bitflags::bitflags;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-use crate::consts;
 use crate::utils::endian::{Bu32, Bu64};
+use crate::{bitflags, consts};
 
 #[repr(C)]
 #[derive(Debug, Clone, Layout, KnownLayout, Immutable, FromBytes, IntoBytes)]
@@ -52,20 +51,18 @@ pub struct Qcow2Hdr {
 pub const QCOW2_MAGIC: [u8; 4] = *b"QFI\xfb";
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Qcow2IncompatibleFeatures: u64 {
-        const DIRTY = 1 << 0;
-        const CORRUPT = 1 << 1;
-        const EXTERNAL_DATA = 1 << 2;
-        const COMPRESSION = 1 << 3;
-        const EXTERNAL_L2 = 1 << 4;
+    pub struct Qcow2IncompatibleFeatures(u64) {
+        DIRTY = 1 << 0;
+        CORRUPT = 1 << 1;
+        EXTERNAL_DATA = 1 << 2;
+        COMPRESSION = 1 << 3;
+        EXTERNAL_L2 = 1 << 4;
     }
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Qcow2CompatibleFeatures: u64 {
-        const LAZY_REFCOUNTS = 1 << 0;
+    pub struct Qcow2CompatibleFeatures(u64) {
+        LAZY_REFCOUNTS = 1 << 0;
     }
 }
 

--- a/alioth/src/device/pl011.rs
+++ b/alioth/src/device/pl011.rs
@@ -16,14 +16,13 @@ use std::collections::VecDeque;
 use std::io;
 use std::sync::Arc;
 
-use bitflags::bitflags;
 use parking_lot::Mutex;
 
 use crate::device::console::{Console, UartRecv};
 use crate::device::{self, MmioDev, Pause};
 use crate::hv::IrqSender;
 use crate::mem::emulated::{Action, Mmio};
-use crate::{hv, mem};
+use crate::{bitflags, hv, mem};
 
 /// RW width 12/8 Data Register
 const UART_DR: u64 = 0x0;
@@ -79,49 +78,49 @@ const PERIPH_ID: [u32; 4] = [0x11, 0x10, 0x14, 0x00];
 const PCELL_ID: [u32; 4] = [0x0d, 0xf0, 0x05, 0xb1];
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy)]
-    pub struct Flag: u16 {
-        const RI = 1 << 8;
+    #[derive(Default)]
+    pub struct Flag(u16) {
+        RI = 1 << 8;
         /// Transmit FIFO empty
-        const TXFE = 1 << 7;
+        TXFE = 1 << 7;
         /// Receive FIFO full
-        const RXFF = 1 << 6;
+        RXFF = 1 << 6;
         /// Transmit FIFO full.
-        const TXFF = 1 << 5;
+        TXFF = 1 << 5;
         /// Receive FIFO empty
-        const RXFE = 1 << 4;
-        const BUSY = 1 << 3;
-        const DCD = 1 << 2;
-        const DSR = 1 << 1;
-        const CTS = 1 << 0;
+        RXFE = 1 << 4;
+        BUSY = 1 << 3;
+        DCD = 1 << 2;
+        DSR = 1 << 1;
+        CTS = 1 << 0;
     }
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy)]
-    pub struct Interrupt: u16 {
+    #[derive(Default)]
+    pub struct Interrupt(u16) {
         /// Overrun error interrupt status.
-        const OERIS = 1 << 10;
+        OERIS = 1 << 10;
         /// Break error interrupt status.
-        const BERIS = 1 << 9;
+        BERIS = 1 << 9;
         /// Parity error interrupt status.
-        const PERIS = 1 << 8;
+        PERIS = 1 << 8;
         /// Framing error interrupt status.
-        const FERIS = 1 << 7;
+        FERIS = 1 << 7;
         /// Receive timeout interrupt status.
-        const RTRIS = 1 << 6;
+        RTRIS = 1 << 6;
         /// Transmit interrupt status.
-        const TXRIS = 1 << 5;
+        TXRIS = 1 << 5;
         /// Receive interrupt status.
-        const RXRIS = 1 << 4;
+        RXRIS = 1 << 4;
         /// nUARTDSR modem interrupt status.
-        const DSRRMIS = 1 << 3;
+        DSRRMIS = 1 << 3;
         /// nUARTDCD modem interrupt status.
-        const DCDRMIS = 1 << 2;
+        DCDRMIS = 1 << 2;
         /// nUARTCTS modem interrupt status.
-        const CTSRMIS = 1 << 1;
+        CTSRMIS = 1 << 1;
         /// nUARTRI modem interrupt status.
-        const RIRMIS = 1 << 0;
+        RIRMIS = 1 << 0;
     }
 }
 

--- a/alioth/src/device/pl031.rs
+++ b/alioth/src/device/pl031.rs
@@ -17,12 +17,11 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use bitflags::bitflags;
 use parking_lot::Mutex;
 
 use crate::device::{self, MmioDev, Pause};
-use crate::mem;
 use crate::mem::emulated::{Action, Mmio};
+use crate::{bitflags, mem};
 
 const RTC_DR: u64 = 0x000;
 const RTC_MR: u64 = 0x004;
@@ -46,9 +45,9 @@ const PERIPH_ID: [u8; 4] = [0x31, 0x10, 0x04, 0x00];
 const PCELL_ID: [u8; 4] = [0x0d, 0xf0, 0x05, 0xb1];
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy)]
-    struct Interrupt: u32 {
-        const RTCINTR = 1 << 0;
+    #[derive(Default)]
+    struct Interrupt(u32) {
+        RTCINTR = 1 << 0;
     }
 }
 

--- a/alioth/src/device/serial.rs
+++ b/alioth/src/device/serial.rs
@@ -17,15 +17,14 @@ use std::io;
 use std::sync::Arc;
 
 use bitfield::bitfield;
-use bitflags::bitflags;
 use parking_lot::Mutex;
 
 use crate::device::console::{Console, UartRecv};
 use crate::device::ioapic::IoApic;
 use crate::device::{self, MmioDev, Pause};
 use crate::hv::MsiSender;
-use crate::mem;
 use crate::mem::emulated::{Action, Mmio};
+use crate::{bitflags, mem};
 
 const TX_HOLDING_REGISTER: u16 = 0x0;
 const RX_BUFFER_REGISTER: u16 = 0x0;
@@ -42,12 +41,12 @@ const SCRATCH_REGISTER: u16 = 0x7;
 
 // offset 0x1, Interrupt Enable Register (IER)
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct InterruptEnable: u8 {
-        const MODEM_STATUS = 1 << 3;
-        const RECEIVER_LINE_STATUS = 1 << 2;
-        const TX_HOLDING_REGISTER_EMPTY = 1 << 1;
-        const RECEIVED_DATA_AVAILABLE = 1 << 0;
+    #[derive(Default)]
+    pub struct InterruptEnable(u8) {
+        MODEM_STATUS = 1 << 3;
+        RECEIVER_LINE_STATUS = 1 << 2;
+        TX_HOLDING_REGISTER_EMPTY = 1 << 1;
+        RECEIVED_DATA_AVAILABLE = 1 << 0;
     }
 }
 
@@ -149,16 +148,15 @@ bitfield! {
 
 // offset 0x5, Line Status Register (LSR)
 bitflags! {
-    #[derive(Debug)]
-    pub struct LineStatus: u8 {
-        const ERROR_IN_RX_FIFO = 1 << 7;
-        const TX_EMPTY = 1 << 6;
-        const TX_HOLDING_REGISTER_EMPTY = 1 << 5;
-        const BREAK_INTERRUPT = 1 << 4;
-        const FRAMING_ERROR = 1 << 3;
-        const PARITY_ERROR = 1 << 2;
-        const OVERRUN_ERROR = 1 << 1;
-        const DATA_READY = 1 << 0;
+    pub struct LineStatus(u8) {
+        ERROR_IN_RX_FIFO = 1 << 7;
+        TX_EMPTY = 1 << 6;
+        TX_HOLDING_REGISTER_EMPTY = 1 << 5;
+        BREAK_INTERRUPT = 1 << 4;
+        FRAMING_ERROR = 1 << 3;
+        PARITY_ERROR = 1 << 2;
+        OVERRUN_ERROR = 1 << 1;
+        DATA_READY = 1 << 0;
     }
 }
 

--- a/alioth/src/fuse/bindings.rs
+++ b/alioth/src/fuse/bindings.rs
@@ -14,10 +14,9 @@
 
 use std::marker::PhantomData;
 
-use bitflags::bitflags;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-use crate::consts;
+use crate::{bitflags, consts};
 
 pub const FUSE_KERNEL_VERSION: u32 = 7;
 pub const FUSE_KERNEL_MINOR_VERSION: u32 = 43;
@@ -25,189 +24,161 @@ pub const FUSE_ROOT_ID: u64 = 1;
 pub const FUSE_UNIQUE_RESEND: u64 = 1 << 63;
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FAttrFlag: u32 {
-        const MODE = 1 << 0;
-        const UID = 1 << 1;
-        const GID = 1 << 2;
-        const SIZE = 1 << 3;
-        const ATIME = 1 << 4;
-        const MTIME = 1 << 5;
-        const FH = 1 << 6;
-        const ATIME_NOW = 1 << 7;
-        const MTIME_NOW = 1 << 8;
-        const LOCKOWNER = 1 << 9;
-        const CTIME = 1 << 10;
-        const KILL_SUIDGID = 1 << 11;
+    pub struct FAttrFlag(u32) {
+        MODE = 1 << 0;
+        UID = 1 << 1;
+        GID = 1 << 2;
+        SIZE = 1 << 3;
+        ATIME = 1 << 4;
+        MTIME = 1 << 5;
+        FH = 1 << 6;
+        ATIME_NOW = 1 << 7;
+        MTIME_NOW = 1 << 8;
+        LOCKOWNER = 1 << 9;
+        CTIME = 1 << 10;
+        KILL_SUIDGID = 1 << 11;
     }
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FOpenFlag: u32 {
-        const DIRECT_IO = 1 << 0;
-        const KEEP_CACHE = 1 << 1;
-        const NONSEEKABLE = 1 << 2;
-        const CACHE_DIR = 1 << 3;
-        const STREAM = 1 << 4;
-        const NOFLUSH = 1 << 5;
-        const PARALLEL_DIRECT_WRITES = 1 << 6;
-        const PASSTHROUGH = 1 << 7;
+    pub struct FOpenFlag(u32) {
+        DIRECT_IO = 1 << 0;
+        KEEP_CACHE = 1 << 1;
+        NONSEEKABLE = 1 << 2;
+        CACHE_DIR = 1 << 3;
+        STREAM = 1 << 4;
+        NOFLUSH = 1 << 5;
+        PARALLEL_DIRECT_WRITES = 1 << 6;
+        PASSTHROUGH = 1 << 7;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseInitFlag: u32 {
-        const ASYNC_READ = 1 << 0;
-        const POSIX_LOCKS = 1 << 1;
-        const FILE_OPS = 1 << 2;
-        const ATOMIC_O_TRUNC = 1 << 3;
-        const EXPORT_SUPPORT = 1 << 4;
-        const BIG_WRITES = 1 << 5;
-        const DONT_MASK = 1 << 6;
-        const SPLICE_WRITE = 1 << 7;
-        const SPLICE_MOVE = 1 << 8;
-        const SPLICE_READ = 1 << 9;
-        const FLOCK_LOCKS = 1 << 10;
-        const HAS_IOCTL_DIR = 1 << 11;
-        const AUTO_INVAL_DATA = 1 << 12;
-        const DO_READDIRPLUS = 1 << 13;
-        const READDIRPLUS_AUTO = 1 << 14;
-        const ASYNC_DIO = 1 << 15;
-        const WRITEBACK_CACHE = 1 << 16;
-        const NO_OPEN_SUPPORT = 1 << 17;
-        const PARALLEL_DIROPS = 1 << 18;
-        const HANDLE_KILLPRIV = 1 << 19;
-        const POSIX_ACL = 1 << 20;
-        const ABORT_ERROR = 1 << 21;
-        const MAX_PAGES = 1 << 22;
-        const CACHE_SYMLINKS = 1 << 23;
-        const NO_OPENDIR_SUPPORT = 1 << 24;
-        const EXPLICIT_INVAL_DATA = 1 << 25;
-        const MAP_ALIGNMENT = 1 << 26;
-        const SUBMOUNTS = 1 << 27;
-        const HANDLE_KILLPRIV_V2 = 1 << 28;
-        const SETXATTR_EXT = 1 << 29;
-        const INIT_EXT = 1 << 30;
-        const INIT_RESERVED = 1 << 31;
+    pub struct FuseInitFlag(u32) {
+        ASYNC_READ = 1 << 0;
+        POSIX_LOCKS = 1 << 1;
+        FILE_OPS = 1 << 2;
+        ATOMIC_O_TRUNC = 1 << 3;
+        EXPORT_SUPPORT = 1 << 4;
+        BIG_WRITES = 1 << 5;
+        DONT_MASK = 1 << 6;
+        SPLICE_WRITE = 1 << 7;
+        SPLICE_MOVE = 1 << 8;
+        SPLICE_READ = 1 << 9;
+        FLOCK_LOCKS = 1 << 10;
+        HAS_IOCTL_DIR = 1 << 11;
+        AUTO_INVAL_DATA = 1 << 12;
+        DO_READDIRPLUS = 1 << 13;
+        READDIRPLUS_AUTO = 1 << 14;
+        ASYNC_DIO = 1 << 15;
+        WRITEBACK_CACHE = 1 << 16;
+        NO_OPEN_SUPPORT = 1 << 17;
+        PARALLEL_DIROPS = 1 << 18;
+        HANDLE_KILLPRIV = 1 << 19;
+        POSIX_ACL = 1 << 20;
+        ABORT_ERROR = 1 << 21;
+        MAX_PAGES = 1 << 22;
+        CACHE_SYMLINKS = 1 << 23;
+        NO_OPENDIR_SUPPORT = 1 << 24;
+        EXPLICIT_INVAL_DATA = 1 << 25;
+        MAP_ALIGNMENT = 1 << 26;
+        SUBMOUNTS = 1 << 27;
+        HANDLE_KILLPRIV_V2 = 1 << 28;
+        SETXATTR_EXT = 1 << 29;
+        INIT_EXT = 1 << 30;
+        INIT_RESERVED = 1 << 31;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseInitFlag2: u32 {
-        const SECURITY_CTX = 1 << 0;
-        const HAS_INODE_DAX = 1 << 1;
-        const CREATE_SUPP_GROUP = 1 << 2;
-        const HAS_EXPIRE_ONLY = 1 << 3;
-        const DIRECT_IO_ALLOW_MMAP = 1 << 4;
-        const PASSTHROUGH = 1 << 5;
-        const NO_EXPORT_SUPPORT = 1 << 6;
-        const HAS_RESEND = 1 << 7;
-        const ALLOW_IDMAP = 1 << 8;
-        const OVER_IO_URING = 1 << 9;
-        const REQUEST_TIMEOUT = 1 << 10;
+    pub struct FuseInitFlag2(u32) {
+        SECURITY_CTX = 1 << 0;
+        HAS_INODE_DAX = 1 << 1;
+        CREATE_SUPP_GROUP = 1 << 2;
+        HAS_EXPIRE_ONLY = 1 << 3;
+        DIRECT_IO_ALLOW_MMAP = 1 << 4;
+        PASSTHROUGH = 1 << 5;
+        NO_EXPORT_SUPPORT = 1 << 6;
+        HAS_RESEND = 1 << 7;
+        ALLOW_IDMAP = 1 << 8;
+        OVER_IO_URING = 1 << 9;
+        REQUEST_TIMEOUT = 1 << 10;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseReleaseFlag: u32 {
-        const FLUSH = 1 << 0;
-        const FLOCK_UNLOCK = 1 << 1;
+    pub struct FuseReleaseFlag(u32) {
+        FLUSH = 1 << 0;
+        FLOCK_UNLOCK = 1 << 1;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseGetattrFlag: u32 {
-        const FH = 1 << 0;
+    pub struct FuseGetattrFlag(u32) {
+        FH = 1 << 0;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseLockFlag: u32 {
-        const FLOCK = 1 << 0;
+    pub struct FuseLockFlag(u32) {
+        FLOCK = 1 << 0;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseWriteFlag: u32 {
-        const CACHE = 1 << 0;
-        const LOCKOWNER = 1 << 1;
-        const KILL_SUIDGID = 1 << 2;
+    pub struct FuseWriteFlag(u32) {
+        CACHE = 1 << 0;
+        LOCKOWNER = 1 << 1;
+        KILL_SUIDGID = 1 << 2;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseReadFlag: u32 {
-        const LOCKOWNER = 1 << 1;
+    pub struct FuseReadFlag(u32) {
+        LOCKOWNER = 1 << 1;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseIoctlFlag: u32 {
-        const COMPAT = 1;
-        const UNRESTRICTED = 2;
-        const RETRY = 4;
-        const BIT_32 = 8;
-        const DIR = 16;
-        const COMPAT_X32 = 32;
-        const MAX_IOV = 256;
+    pub struct FuseIoctlFlag(u32) {
+        COMPAT = 1 << 0;
+        UNRESTRICTED = 1 << 1;
+        RETRY = 1 << 2;
+        BIT_32 = 1 << 3;
+        DIR = 1 << 4;
+        COMPAT_X32 = 1 << 5;
+        MAX_IOV = 1 << 8;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FusePollFlag: u32 {
-        const SCHEDULE_NOTIFY = 1;
+    pub struct FusePollFlag(u32) {
+        SCHEDULE_NOTIFY = 1 << 0;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseFsyncFlag: u32 {
-        const FDATASYNC = 1;
+    pub struct FuseFsyncFlag(u32) {
+        FDATASYNC = 1 << 0;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseAttrFlag: u32 {
-        const SUBMOUNT = 1;
-        const DAX = 2;
+    pub struct FuseAttrFlag(u32) {
+        SUBMOUNT = 1 << 0;
+        DAX = 1 << 1;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseOpenFlag: u32 {
-        const KILL_SUIDGID = 1;
+    pub struct FuseOpenFlag(u32) {
+        KILL_SUIDGID = 1 << 0;
     }
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseSetattrFlag: u32 {
-        const ACL_KILL_SGID = 1;
+    pub struct FuseSetattrFlag(u32) {
+        ACL_KILL_SGID = 1 << 0;
     }
 }
 
@@ -439,12 +410,10 @@ pub struct FuseRenameIn {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct RenameFlag: u32 {
-        const NOREPLACE = 1 << 0;
-        const EXCHANGE = 1 << 1;
-        const WHITEOUT = 1 << 2;
+    pub struct RenameFlag(u32) {
+        NOREPLACE = 1 << 0;
+        EXCHANGE = 1 << 1;
+        WHITEOUT = 1 << 2;
     }
 }
 
@@ -794,10 +763,8 @@ pub struct FuseNotifyInvalInodeOut {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseNotifyInvalFlag: u32 {
-        const EXPIRE_ONLY = 1 << 0;
+    pub struct FuseNotifyInvalFlag(u32) {
+        EXPIRE_ONLY = 1 << 0;
     }
 }
 
@@ -884,11 +851,9 @@ pub struct FuseCopyFileRangeIn {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FuseSetupmappingFlag: u64 {
-        const WRITE = 1 << 0;
-        const READ = 1 << 1;
+    pub struct FuseSetupmappingFlag(u64) {
+        WRITE = 1 << 0;
+        READ = 1 << 1;
     }
 }
 

--- a/alioth/src/loader/linux/bootparams.rs
+++ b/alioth/src/loader/linux/bootparams.rs
@@ -12,35 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bitflags::bitflags;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+use crate::bitflags;
 
 pub const MAGIC_AA55: u16 = 0xaa55;
 pub const MAGIC_HDRS: u32 = 0x53726448; // "HdrS"
 pub const SETUP_HEADER_OFFSET: u64 = 0x01f1;
 
 bitflags! {
-    #[repr(C)]
-    #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
-    pub struct LoadFlags: u8 {
-        const LOADED_HIGH = (1<<0);
-        const KASLR_FLAG = (1<<1);
-        const QUIET_FLAG = (1<<5);
-        const KEEP_SEGMENTS	= (1<<6);
-        const CAN_USE_HEAP = (1<<7);
+    pub struct LoadFlags(u8) {
+        LOADED_HIGH = 1 << 0;
+        KASLR_FLAG = 1 << 1;
+        QUIET_FLAG = 1 << 5;
+        KEEP_SEGMENTS = 1 << 6;
+        CAN_USE_HEAP = 1 << 7;
    }
 }
 
 bitflags! {
-    #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
-    pub struct XLoadFlags: u16 {
-        const XLF_KERNEL_64 = (1<<0);
-        const XLF_CAN_BE_LOADED_ABOVE_4G = (1<<1);
-        const XLF_EFI_HANDOVER_32 = (1<<2);
-        const XLF_EFI_HANDOVER_64 = (1<<3);
-        const XLF_EFI_KEXEC = (1<<4);
-        const XLF_5LEVEL = (1<<5);
-        const XLF_5LEVEL_ENABLED = (1<<6);
+    pub struct XLoadFlags(u16) {
+        XLF_KERNEL_64 = 1 << 0;
+        XLF_CAN_BE_LOADED_ABOVE_4G = 1 << 1;
+        XLF_EFI_HANDOVER_32 = 1 << 2;
+        XLF_EFI_HANDOVER_64 = 1 << 3;
+        XLF_EFI_KEXEC = 1 << 4;
+        XLF_5LEVEL = 1 << 5;
+        XLF_5LEVEL_ENABLED = 1 << 6;
     }
 }
 

--- a/alioth/src/pci/pvpanic.rs
+++ b/alioth/src/pci/pvpanic.rs
@@ -14,8 +14,7 @@
 
 use std::sync::Arc;
 
-use bitflags::bitflags;
-
+use crate::bitflags;
 use crate::device::{self, Pause};
 use crate::mem::emulated::{Action, Mmio};
 use crate::mem::{self, MemRegion};
@@ -26,10 +25,9 @@ use crate::pci::config::{
 use crate::pci::{self, Pci, PciBar};
 
 bitflags! {
-    #[derive(Debug)]
-    struct PvPanicByte: u8 {
-        const PANICKED = 1 << 0;
-        const CRASH_LOADED = 1 << 1;
+    struct PvPanicByte(u8) {
+        PANICKED = 1 << 0;
+        CRASH_LOADED = 1 << 1;
     }
 }
 

--- a/alioth/src/sys/linux/if_tun.rs
+++ b/alioth/src/sys/linux/if_tun.rs
@@ -14,11 +14,10 @@
 
 use std::ffi::{c_int, c_uint, c_ulong};
 
-use bitflags::bitflags;
 use libc::ifreq;
 
 use crate::sys::ioctl::ioctl_iow;
-use crate::{ioctl_read, ioctl_write_ptr, ioctl_write_val};
+use crate::{bitflags, ioctl_read, ioctl_write_ptr, ioctl_write_val};
 
 ioctl_write_ptr!(tun_set_iff, ioctl_iow::<c_int>(b'T', 202), ifreq);
 
@@ -29,14 +28,13 @@ ioctl_read!(tun_get_vnet_hdr_sz, b'T', 215, c_int);
 ioctl_write_ptr!(tun_set_vnet_hdr_sz, b'T', 216, c_int);
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct TunFeature: c_ulong {
-        const CSUM = 0x01;
-        const TSO4 = 0x02;
-        const TSO6 = 0x04;
-        const TSO_ECN = 0x08;
-        const UFO = 0x10;
-        const USO4 = 0x20;
-        const USO6 = 0x40;
+    pub struct TunFeature(c_ulong) {
+        CSUM = 1 << 0;
+        TSO4 = 1 << 1;
+        TSO6 = 1 << 2;
+        TSO_ECN = 1 << 3;
+        UFO = 1 << 4;
+        USO4 = 1 << 5;
+        USO6 = 1 << 6;
     }
 }

--- a/alioth/src/sys/linux/kvm.rs
+++ b/alioth/src/sys/linux/kvm.rs
@@ -16,7 +16,6 @@ use std::fmt::{Debug, Formatter, Result};
 
 #[cfg(target_arch = "aarch64")]
 use bitfield::bitfield;
-use bitflags::bitflags;
 
 #[cfg(target_arch = "x86_64")]
 use crate::ioctl_writeread_buf;
@@ -24,7 +23,7 @@ use crate::sys::ioctl::ioctl_ior;
 #[cfg(target_arch = "x86_64")]
 use crate::sys::ioctl::ioctl_iowr;
 use crate::{
-    consts, ioctl_none, ioctl_read, ioctl_write_buf, ioctl_write_ptr, ioctl_write_val,
+    bitflags, consts, ioctl_none, ioctl_read, ioctl_write_buf, ioctl_write_ptr, ioctl_write_val,
     ioctl_writeread,
 };
 
@@ -50,9 +49,9 @@ pub struct KvmVmType(#[allow(dead_code)] pub u64);
 pub const KVM_MAX_CPUID_ENTRIES: usize = 256;
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct KvmCpuid2Flag: u32 {
-        const SIGNIFCANT_INDEX = 1;
+    #[derive(Default)]
+    pub struct KvmCpuid2Flag(u32) {
+        SIGNIFCANT_INDEX = 1 << 0;
     }
 }
 
@@ -83,25 +82,24 @@ pub const KVM_CPUID_SIGNATURE: u32 = 0x4000_0000;
 pub const KVM_CPUID_FEATURES: u32 = 0x4000_0001;
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct KvmCpuidFeature: u32 {
-        const CLOCKSOURCE = 1 << 0;
-        const NOP_IO_DELAY = 1 << 1;
-        const MMU_OP = 1 << 2;
-        const CLOCKSOURCE2 = 1 << 3;
-        const ASYNC_PF = 1 << 4;
-        const STEAL_TIME = 1 << 5;
-        const PV_EOI = 1 << 6;
-        const PV_UNHALT = 1 << 7;
-        const PV_TLB_FLUSH = 1 << 9;
-        const ASYNC_PF_VMEXIT = 1 << 10;
-        const PV_SEND_IPI = 1 << 11;
-        const POLL_CONTROL = 1 << 12;
-        const PV_SCHED_YIELD = 1 << 13;
-        const ASYNC_PF_INT = 1 << 14;
-        const MSI_EXT_DEST_ID = 1 << 15;
-        const HC_MAP_GPA_RANGE = 1 << 16;
-        const MIGRATION_CONTROL = 1 << 17;
+    pub struct KvmCpuidFeature(u32) {
+        CLOCKSOURCE = 1 << 0;
+        NOP_IO_DELAY = 1 << 1;
+        MMU_OP = 1 << 2;
+        CLOCKSOURCE2 = 1 << 3;
+        ASYNC_PF = 1 << 4;
+        STEAL_TIME = 1 << 5;
+        PV_EOI = 1 << 6;
+        PV_UNHALT = 1 << 7;
+        PV_TLB_FLUSH = 1 << 9;
+        ASYNC_PF_VMEXIT = 1 << 10;
+        PV_SEND_IPI = 1 << 11;
+        POLL_CONTROL = 1 << 12;
+        PV_SCHED_YIELD = 1 << 13;
+        ASYNC_PF_INT = 1 << 14;
+        MSI_EXT_DEST_ID = 1 << 15;
+        HC_MAP_GPA_RANGE = 1 << 16;
+        MIGRATION_CONTROL = 1 << 17;
     }
 }
 
@@ -127,11 +125,11 @@ pub struct KvmMsrs<const N: usize> {
 pub const MAX_IO_MSRS: usize = 256;
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct KvmMemFlag: u32 {
-        const LOG_DIRTY_PAGES = 1 << 0;
-        const READONLY = 1 << 1;
-        const GUEST_MEMFD = 1 << 2;
+    #[derive(Default)]
+    pub struct KvmMemFlag(u32) {
+        LOG_DIRTY_PAGES = 1 << 0;
+        READONLY = 1 << 1;
+        GUEST_MEMFD = 1 << 2;
     }
 }
 
@@ -160,9 +158,9 @@ pub struct KvmUserspaceMemoryRegion2 {
 }
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct KvmMemoryAttribute: u64 {
-        const PRIVATE = 1 << 3;
+    #[derive(Default)]
+    pub struct KvmMemoryAttribute(u64) {
+        PRIVATE = 1 << 3;
     }
 }
 
@@ -378,10 +376,10 @@ pub union KvmSyncRegsBlock {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct KvmIrqfdFlag: u32 {
-        const DEASSIGN = 1 << 0;
-        const RESAMPLE = 1 << 1;
+    #[derive(Default)]
+    pub struct KvmIrqfdFlag(u32) {
+        DEASSIGN = 1 << 0;
+        RESAMPLE = 1 << 1;
     }
 }
 
@@ -480,11 +478,10 @@ impl<const N: usize> Debug for KvmIrqRouting<N> {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-    #[repr(transparent)]
-    pub struct KvmMsiFlag: u32 {
+    #[derive(Default)]
+    pub struct KvmMsiFlag(u32) {
         #[cfg(target_arch = "aarch64")]
-        const VALID_DEVID = 1 << 0;
+        VALID_DEVID = 1 << 0;
     }
 }
 
@@ -514,30 +511,28 @@ consts! {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct KvmX2apicApiFlag: u64 {
-        const USE_32BIT_IDS = 1 << 0;
-        const DISABLE_BROADCAST_QUIRK = 1 << 1;
+    pub struct KvmX2apicApiFlag(u64) {
+        USE_32BIT_IDS = 1 << 0;
+        DISABLE_BROADCAST_QUIRK = 1 << 1;
     }
 }
 
 pub const KVM_HC_MAP_GPA_RANGE: u64 = 12;
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct KvmMapGpaRangeFlag: u64 {
-        const PAGE_2M = 1 << 0;
-        const PAGE_1G = 1 << 1;
-        const ENCRYPTED = 1 << 4;
+    pub struct KvmMapGpaRangeFlag(u64) {
+        PAGE_2M = 1 << 0;
+        PAGE_1G = 1 << 1;
+        ENCRYPTED = 1 << 4;
     }
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct KvmIoEventFdFlag: u32 {
-        const DATA_MATCH = 1 << 0;
-        const PIO = 1 << 1;
-        const DEASSIGN = 1 << 2;
+    #[derive(Default)]
+    pub struct KvmIoEventFdFlag(u32) {
+        DATA_MATCH = 1 << 0;
+        PIO = 1 << 1;
+        DEASSIGN = 1 << 2;
     }
 }
 
@@ -660,12 +655,11 @@ pub struct KvmVcpuInit {
 }
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct KvmArmVcpuFeature: u32 {
-        const POWER_OFF = 1 << 0;
-        const EL1_32BIT = 1 << 1;
-        const PSCI_0_2 = 1 << 2;
-        const PMU_V3 = 1 << 3;
+    pub struct KvmArmVcpuFeature(u32) {
+        POWER_OFF = 1 << 0;
+        EL1_32BIT = 1 << 1;
+        PSCI_0_2 = 1 << 2;
+        PMU_V3 = 1 << 3;
     }
 }
 

--- a/alioth/src/sys/linux/tdx.rs
+++ b/alioth/src/sys/linux/tdx.rs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bitflags::bitflags;
-
 use crate::arch::tdx::TdAttr;
-use crate::consts;
 use crate::sys::kvm::KvmCpuid2;
+use crate::{bitflags, consts};
 
 consts! {
     #[derive(Default)]
@@ -73,8 +71,7 @@ pub struct KvmTdxInitMemRegion {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct KvmTdxInitMemRegionFlag: u32 {
-        const MEASURE_MEMORY_REGION = 1 << 0;
+    pub struct KvmTdxInitMemRegionFlag(u32) {
+        MEASURE_MEMORY_REGION = 1 << 0;
     }
 }

--- a/alioth/src/sys/linux/vfio.rs
+++ b/alioth/src/sys/linux/vfio.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bitflags::bitflags;
-
 use crate::sys::ioctl::ioctl_io;
 use crate::{
-    consts, ioctl_none, ioctl_write_buf, ioctl_write_ptr, ioctl_write_val, ioctl_writeread,
+    bitflags, consts, ioctl_none, ioctl_write_buf, ioctl_write_ptr, ioctl_write_val,
+    ioctl_writeread,
 };
 
 pub const VFIO_TYPE: u8 = b';';
@@ -31,18 +30,17 @@ pub struct VfioInfoCapHeader {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct VfioDeviceInfoFlag: u32 {
-        const RESET = 1 << 0;
-        const PCI = 1 << 1;
-        const PLATFORM = 1 << 2;
-        const AMBA  = 1 << 3;
-        const CCW = 1 << 4;
-        const AP = 1 << 5;
-        const FSL_MC = 1 << 6;
-        const CAPS = 1 << 7;
-        const CDX = 1 << 8;
+    #[derive(Default)]
+    pub struct VfioDeviceInfoFlag(u32) {
+        RESET = 1 << 0;
+        PCI = 1 << 1;
+        PLATFORM = 1 << 2;
+        AMBA = 1 << 3;
+        CCW = 1 << 4;
+        AP = 1 << 5;
+        FSL_MC = 1 << 6;
+        CAPS = 1 << 7;
+        CDX = 1 << 8;
     }
 }
 
@@ -58,13 +56,12 @@ pub struct VfioDeviceInfo {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct VfioRegionInfoFlag: u32 {
-        const READ = 1 << 0;
-        const WRITE = 1 << 1;
-        const MMAP = 1 << 2;
-        const CAPS = 1 << 3;
+    #[derive(Default)]
+    pub struct VfioRegionInfoFlag(u32) {
+        READ = 1 << 0;
+        WRITE = 1 << 1;
+        MMAP = 1 << 2;
+        CAPS = 1 << 3;
     }
 }
 
@@ -101,13 +98,12 @@ consts! {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct VfioIrqInfoFlag: u32 {
-        const EVENTFD = 1 << 0;
-        const MASKABLE = 1 << 1;
-        const AUTOMASKED = 1 << 2;
-        const NORESIZE = 1 << 3;
+    #[derive(Default)]
+    pub struct VfioIrqInfoFlag(u32) {
+        EVENTFD = 1 << 0;
+        MASKABLE = 1 << 1;
+        AUTOMASKED = 1 << 2;
+        NORESIZE = 1 << 3;
     }
 }
 
@@ -132,15 +128,13 @@ pub struct VfioIrqInfo {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Copy, Default)]
-    pub struct VfioIrqSetFlag: u32 {
-        const DATA_NONE = 1 << 0;
-        const DATA_BOOL = 1 << 1;
-        const DATA_EVENTFD = 1 << 2;
-        const ACTION_MASK = 1 << 3;
-        const ACTION_UNMASK = 1 << 4;
-        const ACTION_TRIGGER = 1 << 5;
+    pub struct VfioIrqSetFlag(u32) {
+        DATA_NONE = 1 << 0;
+        DATA_BOOL = 1 << 1;
+        DATA_EVENTFD = 1 << 2;
+        ACTION_MASK = 1 << 3;
+        ACTION_UNMASK = 1 << 4;
+        ACTION_TRIGGER = 1 << 5;
     }
 }
 
@@ -202,12 +196,11 @@ pub struct IommuIoasAlloc {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Default)]
-    pub struct IommuIoasMapFlag: u32 {
-        const FIXED_IOVA = 1 << 0;
-        const WRITEABLE = 1 << 1;
-        const READABLE = 1 << 2;
+    #[derive(Default)]
+    pub struct IommuIoasMapFlag(u32) {
+        FIXED_IOVA = 1 << 0;
+        WRITEABLE = 1 << 1;
+        READABLE = 1 << 2;
     }
 }
 
@@ -233,12 +226,11 @@ pub struct IommuIoasUnmap {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Default)]
-    pub struct VfioDmaMapFlag: u32 {
-        const READ = 1 << 0;
-        const WRITE = 1 << 1;
-        const VADDR = 1 << 2;
+    #[derive(Default)]
+    pub struct VfioDmaMapFlag(u32) {
+        READ = 1 << 0;
+        WRITE = 1 << 1;
+        VADDR = 1 << 2;
     }
 }
 
@@ -253,12 +245,11 @@ pub struct VfioIommuType1DmaMap {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Default)]
-    pub struct VfioDmaUnmapFlag: u32 {
-        const GET_DIRTY_BITMAP  = 1 << 0;
-        const ALL = 1 << 1;
-        const VADDR = 1 << 2;
+    #[derive(Default)]
+    pub struct VfioDmaUnmapFlag(u32) {
+        GET_DIRTY_BITMAP = 1 << 0;
+        ALL = 1 << 1;
+        VADDR = 1 << 2;
     }
 }
 

--- a/alioth/src/sys/linux/vhost.rs
+++ b/alioth/src/sys/linux/vhost.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bitflags::bitflags;
-
-use crate::{ioctl_none, ioctl_read, ioctl_write_buf, ioctl_write_ptr};
+use crate::{bitflags, ioctl_none, ioctl_read, ioctl_write_buf, ioctl_write_ptr};
 
 pub const VHOST_VIRTIO: u8 = 0xAF;
 
@@ -63,11 +61,9 @@ pub struct VirtqAddr {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    #[repr(transparent)]
-    pub struct VhostFeature: u64 {
-        const IOTLB_MSG_V2 = 0x1;
-        const IOTLB_BATCH = 0x2;
+    pub struct VhostFeature(u64) {
+        IOTLB_MSG_V2 = 1 << 0;
+        IOTLB_BATCH = 1 << 1;
     }
 }
 

--- a/alioth/src/sys/macos/block.rs
+++ b/alioth/src/sys/macos/block.rs
@@ -14,8 +14,9 @@
 
 //! https://clang.llvm.org/docs/Block-ABI-Apple.html
 
-use bitflags::bitflags;
 use libc::{c_int, c_ulong, c_void};
+
+use crate::bitflags;
 
 #[repr(C)]
 pub struct BlockDescriptor {
@@ -24,10 +25,9 @@ pub struct BlockDescriptor {
 }
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Default)]
-    pub struct BlockFlag: c_int {
-        const HAS_STRET = 1 << 29;
+    #[derive(Default)]
+    pub struct BlockFlag(c_int) {
+        HAS_STRET = 1 << 29;
     }
 }
 

--- a/alioth/src/sys/macos/hvf.rs
+++ b/alioth/src/sys/macos/hvf.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bitflags::bitflags;
 use libc::c_void;
 
 use crate::arch::reg::{EsrEl2, SReg};
-use crate::consts;
+use crate::{bitflags, consts};
 
 consts! {
     pub struct HvReg(u32) {
@@ -84,12 +83,10 @@ pub struct HvVcpuExit {
 }
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, Default)]
-    #[repr(transparent)]
-    pub struct HvMemoryFlag: u64 {
-        const READ = 1 << 0;
-        const WRITE = 1 << 1;
-        const EXEC = 1 << 2;
+    pub struct HvMemoryFlag(u64) {
+        READ = 1 << 0;
+        WRITE = 1 << 1;
+        EXEC = 1 << 2;
     }
 }
 

--- a/alioth/src/utils/utils.rs
+++ b/alioth/src/utils/utils.rs
@@ -183,6 +183,43 @@ macro_rules! consts {
     }
 }
 
+#[macro_export]
+macro_rules! bitflags {
+    (
+        $(#[$attr:meta])*
+        $vs:vis struct $FlagTy:ident($TyName:ty) {
+            $(
+                $(#[$inner:ident $($args:tt)*])*
+                $FALG:ident = $value:expr;
+            )*
+        }
+    ) => {
+        #[repr(transparent)]
+        #[derive(PartialEq, Eq, Copy, Clone, Hash)]
+        $(#[$attr])*
+        $vs struct $FlagTy($TyName);
+
+        ::bitflags::bitflags! {
+            impl $FlagTy: $TyName {
+                $(
+                    $(#[$inner $($args)*])*
+                    const $FALG = $value;
+                )*
+            }
+        }
+
+        impl ::core::fmt::Debug for $FlagTy {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                if self.is_empty() {
+                    write!(f, "0")
+                } else {
+                    ::bitflags::parser::to_writer(self, f)
+                }
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 #[path = "utils_test.rs"]
 mod tests;

--- a/alioth/src/virtio/dev/balloon.rs
+++ b/alioth/src/virtio/dev/balloon.rs
@@ -19,7 +19,6 @@ use std::sync::mpsc::Receiver;
 use std::thread::JoinHandle;
 
 use alioth_macros::Layout;
-use bitflags::bitflags;
 use libc::{_SC_PAGESIZE, sysconf};
 use mio::Registry;
 use mio::event::Event;
@@ -36,7 +35,7 @@ use crate::virtio::dev::{DevParam, DeviceId, Virtio, WakeEvent};
 use crate::virtio::queue::{QueueReg, Status, VirtQueue};
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{FEATURE_BUILT_IN, IrqSender, Result};
-use crate::{consts, ffi, impl_mmio_for_zerocopy, mem};
+use crate::{bitflags, consts, ffi, impl_mmio_for_zerocopy, mem};
 
 #[repr(C, align(8))]
 #[derive(Debug, Clone, Default, FromBytes, IntoBytes, Immutable, Layout)]
@@ -83,14 +82,13 @@ impl Mmio for BalloonConfigMmio {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct BalloonFeature: u128 {
-        const MUST_TELL_HOST = 1 << 0;
-        const STATS_VQ = 1 << 1;
-        const DEFLATE_ON_OOM = 1 << 2;
-        const FREE_PAGE_HINT = 1 << 3;
-        const PAGE_POISON = 1 << 4;
-        const PAGE_REPORTING = 1 << 5;
+    pub struct BalloonFeature(u128) {
+        MUST_TELL_HOST = 1 << 0;
+        STATS_VQ = 1 << 1;
+        DEFLATE_ON_OOM = 1 << 2;
+        FREE_PAGE_HINT = 1 << 3;
+        PAGE_POISON = 1 << 4;
+        PAGE_REPORTING = 1 << 5;
     }
 }
 

--- a/alioth/src/virtio/dev/blk.rs
+++ b/alioth/src/virtio/dev/blk.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::thread::JoinHandle;
 
-use bitflags::bitflags;
 #[cfg(target_os = "linux")]
 use io_uring::cqueue::Entry as Cqe;
 #[cfg(target_os = "linux")]
@@ -46,7 +45,7 @@ use crate::virtio::worker::WorkerApi;
 use crate::virtio::worker::io_uring::{ActiveIoUring, BufferAction, IoUring, VirtioIoUring};
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{DeviceId, FEATURE_BUILT_IN, IrqSender, Result, error};
-use crate::{consts, impl_mmio_for_zerocopy};
+use crate::{bitflags, consts, impl_mmio_for_zerocopy};
 
 consts! {
     #[derive(FromBytes)]
@@ -84,21 +83,20 @@ pub const VIRTIO_BLK_ID_SIZE: usize = 20;
 const SECTOR_SIZE: usize = 1 << 9;
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct BlockFeature: u128 {
-        const SIZE_MAX = 1 << 1;
-        const SEG_MAX = 1 << 2;
-        const GEOMETRY = 1 << 4;
-        const RO = 1 << 5;
-        const BLK_SIZE = 1 << 6;
-        const FLUSH = 1 << 9;
-        const TOPOLOGY = 1 << 10;
-        const CONFIG_WCE = 1 << 11;
-        const MQ = 1 << 12;
-        const DISCARD = 1 << 13;
-        const WRITE_ZEROS = 1 << 14;
-        const LIFETIME = 1 << 15;
-        const SECURE_ERASE = 1 << 16;
+    pub struct BlockFeature(u128) {
+        SIZE_MAX = 1 << 1;
+        SEG_MAX = 1 << 2;
+        GEOMETRY = 1 << 4;
+        RO = 1 << 5;
+        BLK_SIZE = 1 << 6;
+        FLUSH = 1 << 9;
+        TOPOLOGY = 1 << 10;
+        CONFIG_WCE = 1 << 11;
+        MQ = 1 << 12;
+        DISCARD = 1 << 13;
+        WRITE_ZEROS = 1 << 14;
+        LIFETIME = 1 << 15;
+        SECURE_ERASE = 1 << 16;
     }
 }
 

--- a/alioth/src/virtio/dev/dev.rs
+++ b/alioth/src/virtio/dev/dev.rs
@@ -197,7 +197,7 @@ where
         let (event_tx, event_rx) = mpsc::channel();
         let (handle, notifier) = dev.spawn_worker(event_rx, memory, queue_regs.clone())?;
         log::debug!(
-            "{name}: created with {:x?} {:x?}",
+            "{name}: created with {:x?}, {:x?}",
             VirtioFeature::from_bits_retain(device_feature & !D::Feature::all().bits()),
             D::Feature::from_bits_truncate(device_feature)
         );
@@ -378,7 +378,7 @@ where
         E: IoeventFd,
     {
         log::debug!(
-            "{}: activated with {:x?} {:x?}",
+            "{}: activated with {:x?}, {:x?}",
             self.context.dev.name(),
             VirtioFeature::from_bits_retain(param.feature & !D::Feature::all().bits()),
             D::Feature::from_bits_truncate(param.feature)

--- a/alioth/src/virtio/dev/entropy.rs
+++ b/alioth/src/virtio/dev/entropy.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::thread::JoinHandle;
 
-use bitflags::bitflags;
 use libc::O_NONBLOCK;
 use mio::Registry;
 use mio::event::Event;
@@ -29,7 +28,6 @@ use serde_aco::Help;
 use snafu::ResultExt;
 
 use crate::hv::IoeventFd;
-use crate::mem;
 use crate::mem::emulated::{Action, Mmio};
 use crate::mem::mapped::RamBus;
 use crate::sync::notifier::Notifier;
@@ -37,6 +35,7 @@ use crate::virtio::dev::{DevParam, DeviceId, Virtio, WakeEvent};
 use crate::virtio::queue::{QueueReg, VirtQueue, copy_from_reader};
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{FEATURE_BUILT_IN, IrqSender, Result, error};
+use crate::{bitflags, mem};
 
 #[derive(Debug, Clone)]
 pub struct EntropyConfig;
@@ -56,8 +55,7 @@ impl Mmio for EntropyConfig {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct EntropyFeature: u128 { }
+    pub struct EntropyFeature(u128) { }
 }
 
 #[derive(Debug)]

--- a/alioth/src/virtio/dev/fs/fs.rs
+++ b/alioth/src/virtio/dev/fs/fs.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::thread::JoinHandle;
 
-use bitflags::bitflags;
 use mio::Registry;
 use mio::event::Event;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -43,7 +42,7 @@ use crate::virtio::queue::{DescChain, QueueReg, Status, VirtQueue};
 use crate::virtio::vu::conn::VuChannel;
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{DeviceId, FEATURE_BUILT_IN, IrqSender};
-use crate::{ffi, impl_mmio_for_zerocopy};
+use crate::{bitflags, ffi, impl_mmio_for_zerocopy};
 
 impl DaxRegion for ArcMemPages {
     fn map(
@@ -106,9 +105,8 @@ pub struct FsConfig {
 impl_mmio_for_zerocopy!(FsConfig);
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct FsFeature: u128 {
-        const NOTIFICATION = 1 << 0;
+    pub struct FsFeature(u128) {
+        NOTIFICATION = 1 << 0;
     }
 }
 

--- a/alioth/src/virtio/dev/net/net.rs
+++ b/alioth/src/virtio/dev/net/net.rs
@@ -19,11 +19,10 @@ pub mod vmnet;
 
 use std::fmt::Debug;
 
-use bitflags::bitflags;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::device::net::MacAddr;
-use crate::{consts, impl_mmio_for_zerocopy};
+use crate::{bitflags, consts, impl_mmio_for_zerocopy};
 
 #[repr(C, align(8))]
 #[derive(Debug, Default, FromBytes, Immutable, IntoBytes)]
@@ -77,38 +76,37 @@ pub struct CtrlHdr {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct NetFeature: u128 {
-        const CSUM = 1 << 0;
-        const GUEST_CSUM = 1 << 1;
-        const CTRL_GUEST_OFFLOADS = 1 << 2;
-        const MTU = 1 << 3;
-        const MAC = 1 << 5;
-        const GUEST_TSO4 = 1 << 7;
-        const GUEST_TSO6 = 1 << 8;
-        const GUEST_ECN = 1 << 9;
-        const GUEST_UFO = 1 << 10;
-        const HOST_TSO4 = 1 << 11;
-        const HOST_TSO6 = 1 << 12;
-        const HOST_ECN = 1 << 13;
-        const HOST_UFO = 1 << 14;
-        const MRG_RXBUF = 1 << 15;
-        const STATUS = 1 << 16;
-        const CTRL_VQ = 1 << 17;
-        const CTRL_RX = 1 << 18;
-        const CTRL_VLAN = 1 << 19;
-        const GUEST_ANNOUNCE = 1 << 21;
-        const MQ = 1 << 22;
-        const CTRL_MAC_ADDR = 1 << 23;
-        const GUEST_USO4 = 1 << 54;
-        const GUEST_USO6 = 1 << 55;
-        const HOST_USO = 1 << 56;
-        const HASH_REPORT = 1 << 57;
-        const GUEST_HDRLEN = 1 << 59;
-        const RSS = 1 << 60;
-        const RSC_EXT = 1 << 61;
-        const STANDBY = 1 << 62;
-        const SPEED_DUPLEX = 1 << 63;
+    pub struct NetFeature(u128) {
+        CSUM = 1 << 0;
+        GUEST_CSUM = 1 << 1;
+        CTRL_GUEST_OFFLOADS = 1 << 2;
+        MTU = 1 << 3;
+        MAC = 1 << 5;
+        GUEST_TSO4 = 1 << 7;
+        GUEST_TSO6 = 1 << 8;
+        GUEST_ECN = 1 << 9;
+        GUEST_UFO = 1 << 10;
+        HOST_TSO4 = 1 << 11;
+        HOST_TSO6 = 1 << 12;
+        HOST_ECN = 1 << 13;
+        HOST_UFO = 1 << 14;
+        MRG_RXBUF = 1 << 15;
+        STATUS = 1 << 16;
+        CTRL_VQ = 1 << 17;
+        CTRL_RX = 1 << 18;
+        CTRL_VLAN = 1 << 19;
+        GUEST_ANNOUNCE = 1 << 21;
+        MQ = 1 << 22;
+        CTRL_MAC_ADDR = 1 << 23;
+        GUEST_USO4 = 1 << 54;
+        GUEST_USO6 = 1 << 55;
+        HOST_USO = 1 << 56;
+        HASH_REPORT = 1 << 57;
+        GUEST_HDRLEN = 1 << 59;
+        RSS = 1 << 60;
+        RSC_EXT = 1 << 61;
+        STANDBY = 1 << 62;
+        SPEED_DUPLEX = 1 << 63;
     }
 }
 

--- a/alioth/src/virtio/dev/vsock/vsock.rs
+++ b/alioth/src/virtio/dev/vsock/vsock.rs
@@ -18,10 +18,9 @@ mod vhost_vsock;
 
 use std::num::Wrapping;
 
-use bitflags::bitflags;
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
-use crate::{consts, impl_mmio_for_zerocopy};
+use crate::{bitflags, consts, impl_mmio_for_zerocopy};
 
 pub use self::uds_vsock::{UdsVsock, UdsVsockParam};
 #[cfg(target_os = "linux")]
@@ -48,10 +47,9 @@ pub struct VsockConfig {
 impl_mmio_for_zerocopy!(VsockConfig);
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct VsockFeature: u128 {
-        const STREAM = 1 << 0;
-        const SEQPACKET = 1 << 1;
+    pub struct VsockFeature(u128) {
+        STREAM = 1 << 0;
+        SEQPACKET = 1 << 1;
     }
 }
 
@@ -95,9 +93,8 @@ pub struct VsockHeader {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct ShutdownFlag: u32 {
-        const RECEIVE = 1 << 0;
-        const SEND = 1 << 1;
+    pub struct ShutdownFlag(u32) {
+        RECEIVE = 1 << 0;
+        SEND = 1 << 1;
     }
 }

--- a/alioth/src/virtio/queue/queue.rs
+++ b/alioth/src/virtio/queue/queue.rs
@@ -17,25 +17,22 @@ pub mod split;
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::hash::Hash;
 use std::io::{ErrorKind, IoSlice, IoSliceMut, Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering, fence};
 
-use bitflags::bitflags;
-
+use crate::bitflags;
 use crate::mem::mapped::Ram;
 use crate::virtio::{IrqSender, Result, error};
 
 pub const QUEUE_SIZE_MAX: u16 = 256;
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct DescFlag: u16 {
-        const NEXT = 1;
-        const WRITE = 2;
-        const INDIRECT = 4;
-        const AVAIL = 1 << 7;
-        const USED = 1 << 15;
+    pub struct DescFlag(u16) {
+        NEXT = 1 << 0;
+        WRITE = 1 << 1;
+        INDIRECT = 1 << 2;
+        AVAIL = 1 << 7;
+        USED = 1 << 15;
     }
 }
 

--- a/alioth/src/virtio/queue/split.rs
+++ b/alioth/src/virtio/queue/split.rs
@@ -17,9 +17,9 @@ use std::mem::size_of;
 use std::sync::atomic::{Ordering, fence};
 
 use alioth_macros::Layout;
-use bitflags::bitflags;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
+use crate::bitflags;
 use crate::mem::mapped::Ram;
 use crate::virtio::queue::{DescChain, DescFlag, QueueReg, VirtQueue};
 use crate::virtio::{Result, error};
@@ -34,9 +34,8 @@ pub struct Desc {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct AvailFlag: u16 {
-        const NO_INTERRUPT = 1;
+    pub struct AvailFlag(u16) {
+        NO_INTERRUPT = 1 << 0;
     }
 }
 
@@ -48,9 +47,8 @@ pub struct AvailHeader {
 }
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct UsedFlag: u16 {
-        const NO_NOTIFY = 1;
+    pub struct UsedFlag(u16) {
+        NO_NOTIFY = 1 << 0;
     }
 }
 

--- a/alioth/src/virtio/virtio.rs
+++ b/alioth/src/virtio/virtio.rs
@@ -29,9 +29,9 @@ use std::fmt::Debug;
 use std::os::fd::BorrowedFd;
 use std::path::Path;
 
-use bitflags::bitflags;
 use snafu::Snafu;
 
+use crate::bitflags;
 use crate::errors::{DebugTrace, trace_error};
 
 #[trace_error]
@@ -85,14 +85,13 @@ pub enum Error {
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct VirtioFeature: u128 {
-        const INDIRECT_DESC = 1 << 28;
-        const EVENT_IDX = 1 << 29;
-        const VHOST_PROTOCOL = 1 << 30;
-        const VERSION_1 = 1 << 32;
-        const ACCESS_PLATFORM = 1 << 33;
-        const RING_PACKED = 1 << 34;
+    pub struct VirtioFeature(u128) {
+        INDIRECT_DESC = 1 << 28;
+        EVENT_IDX = 1 << 29;
+        VHOST_PROTOCOL = 1 << 30;
+        VERSION_1 = 1 << 32;
+        ACCESS_PLATFORM = 1 << 33;
+        RING_PACKED = 1 << 34;
     }
 }
 
@@ -114,14 +113,14 @@ pub enum DeviceId {
 }
 
 bitflags! {
-    #[derive(Debug, Default, Clone, Copy)]
-    pub struct DevStatus: u8 {
-        const ACK = 1;
-        const DRIVER = 2;
-        const DRIVER_OK = 4;
-        const FEATURES_OK = 8;
-        const NEEDS_RESET = 64;
-        const FAILED = 128;
+    #[derive(Default)]
+    pub struct DevStatus(u8) {
+        ACK = 1 << 0;
+        DRIVER = 1 << 1;
+        DRIVER_OK = 1 << 2;
+        FEATURES_OK = 1 << 3;
+        NEEDS_RESET = 1 << 6;
+        FAILED = 1 << 7;
     }
 }
 

--- a/alioth/src/virtio/vu/bindings.rs
+++ b/alioth/src/virtio/vu/bindings.rs
@@ -13,35 +13,32 @@
 // limitations under the License.
 
 use bitfield::bitfield;
-use bitflags::bitflags;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-use crate::consts;
+use crate::{bitflags, consts};
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    #[repr(transparent)]
-    pub struct VuFeature: u64 {
-        const MQ = 1 << 0;
-        const LOG_SHMFD = 1 << 1;
-        const RARP = 1 << 2;
-        const REPLY_ACK = 1 << 3;
-        const MTU = 1 << 4;
-        const BACKEND_REQ = 1 << 5;
-        const CROSS_ENDIAN = 1 << 6;
-        const CRYPTO_SESSION = 1 << 7;
-        const PAGEFAULT = 1 << 8;
-        const CONFIG = 1 << 9;
-        const BACKEND_SEND_FD = 1 << 10;
-        const HOST_NOTIFIER = 1 << 11;
-        const INFLIGHT_SHMFD = 1 << 12;
-        const RESET_DEVICE = 1 << 13;
-        const INBAND_NOTIFICATIONS = 1 << 14;
-        const CONFIGURE_MEM_SLOTS = 1 << 15;
-        const STATUS = 1 << 16;
-        const XEN_MMAP = 1 << 17;
-        const SHARED_OBJECT = 1 << 18;
-        const DEVICE_STATE = 1 << 19;
+    pub struct VuFeature(u64) {
+        MQ = 1 << 0;
+        LOG_SHMFD = 1 << 1;
+        RARP = 1 << 2;
+        REPLY_ACK = 1 << 3;
+        MTU = 1 << 4;
+        BACKEND_REQ = 1 << 5;
+        CROSS_ENDIAN = 1 << 6;
+        CRYPTO_SESSION = 1 << 7;
+        PAGEFAULT = 1 << 8;
+        CONFIG = 1 << 9;
+        BACKEND_SEND_FD = 1 << 10;
+        HOST_NOTIFIER = 1 << 11;
+        INFLIGHT_SHMFD = 1 << 12;
+        RESET_DEVICE = 1 << 13;
+        INBAND_NOTIFICATIONS = 1 << 14;
+        CONFIGURE_MEM_SLOTS = 1 << 15;
+        STATUS = 1 << 16;
+        XEN_MMAP = 1 << 17;
+        SHARED_OBJECT = 1 << 18;
+        DEVICE_STATE = 1 << 19;
     }
 }
 

--- a/alioth/src/virtio/vu/frontend.rs
+++ b/alioth/src/virtio/vu/frontend.rs
@@ -19,7 +19,6 @@ use std::sync::atomic::Ordering;
 use std::sync::mpsc::Receiver;
 use std::thread::JoinHandle;
 
-use bitflags::bitflags;
 use mio::event::Event;
 use mio::unix::SourceFd;
 use mio::{Interest, Registry, Token};
@@ -40,11 +39,10 @@ use crate::virtio::vu::conn::{VuChannel, VuSession};
 use crate::virtio::vu::error as vu_error;
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{DevStatus, DeviceId, IrqSender, Result, VirtioFeature, error};
-use crate::{ffi, mem};
+use crate::{bitflags, ffi, mem};
 
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct VuDevFeature: u128 { }
+    pub struct VuDevFeature(u128) { }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Define a custom `bitflags!` macro to simplify bitflag definitions and ensure compatibility with external derive macros like `zerocopy`.

This new macro wraps `bitflags::bitflags!`, automatically derives the `Debug` trait, and introduces a more concise and idiomatic syntax.

This change is applied throughout the codebase, replacing direct invocations of the `bitflags::bitflags!` macro.