### PR TITLE
fix(kvm): ignore non-zero CPUID index if SIGNIFCANT_INDEX is absent

### DIFF
--- a/alioth/src/hv/kvm/kvm_x86_64.rs
+++ b/alioth/src/hv/kvm/kvm_x86_64.rs
@@ -28,7 +28,7 @@ impl From<KvmCpuidEntry2> for (CpuidIn, CpuidResult) {
     fn from(value: KvmCpuidEntry2) -> Self {
         let in_ = CpuidIn {
             func: value.function,
-            index: if value.flags.contains(KvmCpuid2Flag::SIGNIFCANT_INDEX) || value.index > 0 {
+            index: if value.flags.contains(KvmCpuid2Flag::SIGNIFCANT_INDEX) {
                 Some(value.index)
             } else {
                 None

--- a/alioth/src/hv/kvm/kvm_x86_64_test.rs
+++ b/alioth/src/hv/kvm/kvm_x86_64_test.rs
@@ -42,7 +42,7 @@ fn test_get_supported_cpuid() {
 #[case(
     KvmCpuidEntry2 {
         function: 0,
-        index: 0,
+        index: 1,
         flags: KvmCpuid2Flag::empty(),
         eax: 0x10,
         ebx: u32::from_le_bytes(*b"Auth"),


### PR DESCRIPTION
Fixes: ca9a64b8636b ("feat(tdx): initialize TDX VMs with supported CPUID features")