### PR TITLE
refactor(board): move CPU topology initialization from board to CLI

### DIFF
--- a/alioth-cli/src/boot/boot.rs
+++ b/alioth-cli/src/boot/boot.rs
@@ -241,7 +241,7 @@ fn parse_cpu_arg(
     num_cpu: u16,
     objects: &HashMap<&str, &str>,
 ) -> Result<CpuConfig, Error> {
-    let config = if let Some(arg) = arg {
+    let mut config = if let Some(arg) = arg {
         serde_aco::from_args(&arg, objects).context(error::ParseArg { arg })?
     } else {
         eprintln!("Please update the cmd line to --cpu count={num_cpu}");
@@ -250,6 +250,13 @@ fn parse_cpu_arg(
             ..Default::default()
         }
     };
+    if config.topology.sockets == 0 {
+        config.topology.sockets = 1;
+    }
+    let vcpus_per_core = 1 + config.topology.smt as u16;
+    if config.topology.cores == 0 {
+        config.topology.cores = config.count / config.topology.sockets as u16 / vcpus_per_core;
+    }
     Ok(config)
 }
 

--- a/alioth-cli/src/boot/boot_test.rs
+++ b/alioth-cli/src/boot/boot_test.rs
@@ -250,7 +250,7 @@ fn test_parse_net_arg(#[case] arg: &str, #[case] want: NetParam) {
     HashMap::new(),
     CpuConfig {
         count: 16,
-        topology: CpuTopology::default(),
+        topology: CpuTopology { smt: false, cores: 16, sockets: 1 }
     }
 )]
 fn test_parse_cpu_arg(

--- a/alioth/src/board/board.rs
+++ b/alioth/src/board/board.rs
@@ -116,20 +116,11 @@ pub struct CpuConfig {
 }
 
 impl CpuConfig {
-    pub fn fixup(&mut self) -> Result<()> {
-        if self.topology.sockets == 0 {
-            self.topology.sockets = 1;
-        }
+    pub fn validate(&self) -> bool {
         let vcpus_per_core = 1 + self.topology.smt as u16;
-        if self.topology.cores == 0 {
-            self.topology.cores = self.count / self.topology.sockets as u16 / vcpus_per_core;
-        }
         let vcpus_per_socket = self.topology.cores * vcpus_per_core;
         let count = self.topology.sockets as u16 * vcpus_per_socket;
-        if count != self.count {
-            return error::InvalidCpuTopology.fail();
-        }
-        Ok(())
+        count == self.count
     }
 }
 
@@ -147,8 +138,11 @@ impl BoardConfig {
         (self.mem.size.saturating_sub(RAM_32_SIZE) + MEM_64_START).next_power_of_two()
     }
 
-    pub fn config_fixup(&mut self) -> Result<()> {
-        self.cpu.fixup()
+    pub fn validate(&self) -> Result<()> {
+        if !self.cpu.validate() {
+            return error::InvalidCpuTopology.fail();
+        }
+        Ok(())
     }
 }
 
@@ -172,11 +166,11 @@ impl<V> Board<V>
 where
     V: Vm,
 {
-    pub fn new<H>(hv: &H, mut config: BoardConfig) -> Result<Self>
+    pub fn new<H>(hv: &H, config: BoardConfig) -> Result<Self>
     where
         H: Hypervisor<Vm = V>,
     {
-        config.config_fixup()?;
+        config.validate()?;
 
         let vm_config = VmConfig {
             coco: config.coco.clone(),

--- a/alioth/src/board/board_test.rs
+++ b/alioth/src/board/board_test.rs
@@ -12,39 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use assert_matches::assert_matches;
 use rstest::rstest;
 
-use crate::board::{CpuConfig, CpuTopology, Error};
+use crate::board::{CpuConfig, CpuTopology};
 
-#[test]
-fn test_cpu_topology_fixup() {
-    let mut empty = CpuConfig {
-        count: 2,
-        topology: CpuTopology::default(),
-    };
-    empty.fixup().unwrap();
-    assert_matches!(
-        empty,
-        CpuConfig {
-            count: 2,
-            topology: CpuTopology {
-                smt: false,
-                cores: 2,
-                sockets: 1
-            }
-        }
-    );
-
-    let mut invalid = CpuConfig {
-        count: 2,
-        topology: CpuTopology {
-            smt: true,
-            cores: 2,
-            sockets: 1,
-        },
-    };
-    assert_matches!(invalid.fixup(), Err(Error::InvalidCpuTopology { .. }))
+#[rstest]
+#[case(CpuConfig {
+    count: 2,
+    topology: CpuTopology {
+        smt: false,
+        cores: 2,
+        sockets: 1,
+    },
+}, true)]
+#[case(CpuConfig {
+    count: 2,
+    topology: CpuTopology {
+        smt: true,
+        cores: 2,
+        sockets: 1,
+    },
+}, false)]
+fn test_cpu_topology_validate(#[case] config: CpuConfig, #[case] expected: bool) {
+    assert_eq!(config.validate(), expected);
 }
 
 #[rstest]


### PR DESCRIPTION
Relocate the logic for filling missing CPU topology values from the alioth library to the CLI argument parsing phase.