### PR TITLE
style: rename VM config structs to use 'Spec' suffix

### DIFF
--- a/alioth-cli/src/boot/boot.rs
+++ b/alioth-cli/src/boot/boot.rs
@@ -18,26 +18,26 @@ use std::collections::HashMap;
 use std::mem;
 use std::path::{Path, PathBuf};
 
-use alioth::board::{BoardConfig, CpuConfig};
+use alioth::board::{BoardSpec, CpuSpec};
 #[cfg(target_arch = "x86_64")]
-use alioth::device::fw_cfg::FwCfgItemParam;
+use alioth::device::fw_cfg::FwCfgItemSpec;
 use alioth::errors::{DebugTrace, trace_error};
 #[cfg(target_os = "macos")]
 use alioth::hv::Hvf;
 #[cfg(target_os = "linux")]
 use alioth::hv::Kvm;
-use alioth::hv::{Coco, HvConfig, Hypervisor};
-use alioth::loader::{Executable, Payload};
-use alioth::mem::{MemBackend, MemConfig};
+use alioth::hv::{CocoSpec, HvSpec, Hypervisor};
+use alioth::loader::{Executable, PayloadSpec};
+use alioth::mem::{MemBackend, MemSpec};
 #[cfg(target_os = "linux")]
-use alioth::vfio::{CdevParam, ContainerParam, GroupParam, IoasParam};
+use alioth::vfio::{VfioCdevSpec, VfioContainerSpec, VfioGroupSpec, VfioIoasSpec};
 #[cfg(target_os = "linux")]
 use alioth::virtio::DeviceId;
-use alioth::virtio::dev::balloon::BalloonParam;
-use alioth::virtio::dev::blk::BlkFileParam;
-use alioth::virtio::dev::entropy::EntropyParam;
+use alioth::virtio::dev::balloon::BalloonSpec;
+use alioth::virtio::dev::blk::BlkFileSpec;
+use alioth::virtio::dev::entropy::EntropySpec;
 #[cfg(target_os = "linux")]
-use alioth::virtio::vu::frontend::VuFrontendParam;
+use alioth::virtio::vu::frontend::VuFrontendSpec;
 use alioth::virtio::worker::WorkerApi;
 use alioth::vm::Machine;
 use clap::Args;
@@ -46,7 +46,7 @@ use snafu::{ResultExt, Snafu};
 
 use crate::objects::{DOC_OBJECTS, parse_objects};
 
-use self::config::{BlkParam, Config, FsParam, NetParam, VsockParam};
+use self::config::{BlkSpec, FsSpec, NetSpec, VmSpec, VsockSpec};
 
 #[trace_error]
 #[derive(Snafu, DebugTrace)]
@@ -74,7 +74,7 @@ pub enum Error {
 #[command(arg_required_else_help = true, alias("run"))]
 pub struct BootArgs {
     #[arg(long, help(
-        help_text::<HvConfig>("Specify the Hypervisor to run on.")
+        help_text::<HvSpec>("Specify the Hypervisor to run on.")
     ), value_name = "HV")]
     hypervisor: Option<String>,
 
@@ -104,7 +104,7 @@ pub struct BootArgs {
     num_cpu: u16,
 
     #[arg(short('p'), long, help(
-        help_text::<CpuConfig>("Configure the VCPUs of the guest.")
+        help_text::<CpuSpec>("Configure the VCPUs of the guest.")
     ))]
     cpu: Option<Box<str>>,
 
@@ -113,7 +113,7 @@ pub struct BootArgs {
     mem_size: String,
 
     #[arg(short, long, help(
-        help_text::<MemConfig>("Specify the memory of the guest.")
+        help_text::<MemSpec>("Specify the memory of the guest.")
     ))]
     memory: Option<String>,
 
@@ -123,7 +123,7 @@ pub struct BootArgs {
 
     #[cfg(target_arch = "x86_64")]
     #[arg(long, help(
-        help_text::<FwCfgItemParam>("Add an extra item to the fw_cfg device.")
+        help_text::<FwCfgItemSpec>("Add an extra item to the fw_cfg device.")
     ), value_name = "ITEM")]
     fw_cfg: Vec<String>,
 
@@ -132,79 +132,79 @@ pub struct BootArgs {
     entropy: bool,
 
     #[arg(long, help(
-        help_text::<NetParam>("Add a VirtIO net device.")
+        help_text::<NetSpec>("Add a VirtIO net device.")
     ))]
     net: Vec<String>,
 
     #[arg(long, help(
-        help_text::<BlkParam>("Add a VirtIO block device.")
+        help_text::<BlkSpec>("Add a VirtIO block device.")
     ))]
     blk: Vec<String>,
 
     #[arg(long, help(
-        help_text::<Coco>("Enable confidential compute supported by host platform.")
+        help_text::<CocoSpec>("Enable confidential compute supported by host platform.")
     ))]
     coco: Option<String>,
 
     #[arg(long, help(
-        help_text::<FsParam>("Add a VirtIO filesystem device.")
+        help_text::<FsSpec>("Add a VirtIO filesystem device.")
     ))]
     fs: Vec<String>,
 
     #[arg(long, help(
-        help_text::<VsockParam>("Add a VirtIO vsock device.")
+        help_text::<VsockSpec>("Add a VirtIO vsock device.")
     ))]
     vsock: Option<String>,
 
     #[cfg(target_os = "linux")]
-    #[arg(long, help(help_text::<CdevParam>(
+    #[arg(long, help(help_text::<VfioCdevSpec>(
         "Assign a host PCI device to the guest using IOMMUFD API."
     ) ))]
     vfio_cdev: Vec<String>,
 
     #[cfg(target_os = "linux")]
-    #[arg(long, help(help_text::<IoasParam>("Create a new IO address space.")))]
+    #[arg(long, help(help_text::<VfioIoasSpec>("Create a new IO address space.")))]
     vfio_ioas: Vec<String>,
 
     #[cfg(target_os = "linux")]
-    #[arg(long, help(help_text::<GroupParam>(
+    #[arg(long, help(help_text::<VfioGroupSpec>(
         "Assign a host PCI device to the guest using legacy VFIO API."
     )))]
     vfio_group: Vec<String>,
 
     #[cfg(target_os = "linux")]
-    #[arg(long, help(help_text::<ContainerParam>("Add a new VFIO container.")))]
+    #[arg(long, help(help_text::<VfioContainerSpec>("Add a new VFIO container.")))]
     vfio_container: Vec<String>,
 
     #[arg(long)]
-    #[arg(long, help(help_text::<BalloonParam>("Add a VirtIO balloon device.")))]
+    #[arg(long, help(help_text::<BalloonSpec>("Add a VirtIO balloon device.")))]
     balloon: Option<String>,
 
     #[arg(short, long("object"), help = DOC_OBJECTS, value_name = "OBJECT")]
     objects: Vec<String>,
 }
 
-fn parse_net_arg(arg: &str, objects: &HashMap<&str, &str>) -> serde_aco::Result<NetParam> {
+fn parse_net_arg(arg: &str, objects: &HashMap<&str, &str>) -> serde_aco::Result<NetSpec> {
     #[cfg(target_os = "linux")]
     if let Ok(param) = serde_aco::from_args(arg, objects) {
         Ok(param)
     } else {
         let param = serde_aco::from_args(arg, objects)?;
-        Ok(NetParam::Tap(param))
+        Ok(NetSpec::Tap(param))
     }
 
     #[cfg(target_os = "macos")]
     serde_aco::from_args(arg, objects)
 }
 
-fn parse_blk_arg(arg: &str, objects: &HashMap<&str, &str>) -> BlkParam {
+fn parse_blk_arg(arg: &str, objects: &HashMap<&str, &str>) -> BlkSpec {
     if let Ok(param) = serde_aco::from_args(arg, objects) {
         param
     } else if let Ok(param) = serde_aco::from_args(arg, objects) {
-        BlkParam::File(param)
+        BlkSpec::File(param)
     } else {
         eprintln!("Please update the cmd line to --blk file,path={arg}");
-        BlkParam::File(BlkFileParam {
+        BlkSpec::File(BlkFileSpec {
             path: PathBuf::from(arg).into(),
             readonly: false,
             api: WorkerApi::Mio,
@@ -216,13 +216,13 @@ fn parse_mem_arg(
     arg: Option<String>,
     mem_size: String,
     objects: &HashMap<&str, &str>,
-) -> Result<MemConfig, Error> {
-    let config = if let Some(arg) = arg {
+) -> Result<MemSpec, Error> {
+    let spec = if let Some(arg) = arg {
         serde_aco::from_args(&arg, objects).context(error::ParseArg { arg })?
     } else {
         #[cfg(target_os = "linux")]
         eprintln!("Please update the cmd line to --memory size={mem_size},backend=memfd");
-        MemConfig {
+        MemSpec {
             size: serde_aco::from_args(&mem_size, objects)
                 .context(error::ParseArg { arg: mem_size })?,
             #[cfg(target_os = "linux")]
@@ -232,35 +232,35 @@ fn parse_mem_arg(
             ..Default::default()
         }
     };
-    Ok(config)
+    Ok(spec)
 }
 
 fn parse_cpu_arg(
     arg: Option<Box<str>>,
     num_cpu: u16,
     objects: &HashMap<&str, &str>,
-) -> Result<CpuConfig, Error> {
-    let mut config = if let Some(arg) = arg {
+) -> Result<CpuSpec, Error> {
+    let mut spec = if let Some(arg) = arg {
         serde_aco::from_args(&arg, objects).context(error::ParseArg { arg })?
     } else {
         eprintln!("Please update the cmd line to --cpu count={num_cpu}");
-        CpuConfig {
+        CpuSpec {
             count: num_cpu,
             ..Default::default()
         }
     };
-    if config.topology.sockets == 0 {
-        config.topology.sockets = 1;
+    if spec.topology.sockets == 0 {
+        spec.topology.sockets = 1;
     }
-    let vcpus_per_core = 1 + config.topology.smt as u16;
-    if config.topology.cores == 0 {
-        config.topology.cores = config.count / config.topology.sockets as u16 / vcpus_per_core;
+    let vcpus_per_core = 1 + spec.topology.smt as u16;
+    if spec.topology.cores == 0 {
+        spec.topology.cores = spec.count / spec.topology.sockets as u16 / vcpus_per_core;
     }
-    Ok(config)
+    Ok(spec)
 }
 
-fn parse_payload_arg(args: &mut BootArgs) -> Payload {
-    let mut payload = Payload {
+fn parse_payload_arg(args: &mut BootArgs) -> PayloadSpec {
+    let mut payload = PayloadSpec {
         firmware: args.firmware.take(),
         initramfs: args.initramfs.take(),
         cmdline: args.cmdline.take(),
@@ -274,19 +274,19 @@ fn parse_payload_arg(args: &mut BootArgs) -> Payload {
     payload
 }
 
-fn parse_args(mut args: BootArgs, objects: HashMap<&str, &str>) -> Result<Config, Error> {
+fn parse_args(mut args: BootArgs, objects: HashMap<&str, &str>) -> Result<VmSpec, Error> {
     let payload = parse_payload_arg(&mut args);
 
-    let mut board_config = BoardConfig::default();
+    let mut board_spec = BoardSpec::default();
     if let Some(arg) = args.coco {
         let param = serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?;
-        board_config.coco = Some(param);
+        board_spec.coco = Some(param);
     };
-    board_config.mem = parse_mem_arg(args.memory, args.mem_size, &objects)?;
-    board_config.cpu = parse_cpu_arg(args.cpu, args.num_cpu, &objects)?;
+    board_spec.mem = parse_mem_arg(args.memory, args.mem_size, &objects)?;
+    board_spec.cpu = parse_cpu_arg(args.cpu, args.num_cpu, &objects)?;
 
-    let mut config = Config {
-        board: board_config,
+    let mut spec = VmSpec {
+        board: board_spec,
         pvpanic: args.pvpanic,
         payload,
         ..Default::default()
@@ -295,64 +295,64 @@ fn parse_args(mut args: BootArgs, objects: HashMap<&str, &str>) -> Result<Config
     #[cfg(target_arch = "x86_64")]
     for arg in args.fw_cfg {
         let param = serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?;
-        config.fw_cfg.push(param);
+        spec.fw_cfg.push(param);
     }
 
     if args.entropy {
-        config.entropy = Some(EntropyParam::default());
+        spec.entropy = Some(EntropySpec::default());
     }
 
     for arg in args.net {
         let param = parse_net_arg(&arg, &objects).context(error::ParseArg { arg })?;
-        config.net.push(param);
+        spec.net.push(param);
     }
 
     for arg in args.blk {
         let param = parse_blk_arg(&arg, &objects);
-        config.blk.push(param);
+        spec.blk.push(param);
     }
 
     for arg in args.fs {
         let param = serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?;
-        config.fs.push(param);
+        spec.fs.push(param);
     }
 
     if let Some(arg) = args.vsock {
         let param = serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?;
-        config.vsock = Some(param);
+        spec.vsock = Some(param);
     }
 
     if let Some(arg) = args.balloon {
         let param = serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?;
-        config.balloon = Some(param);
+        spec.balloon = Some(param);
     }
 
     #[cfg(target_os = "linux")]
     for arg in args.vfio_ioas {
         let param = serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?;
-        config.vfio_ioas.push(param);
+        spec.vfio_ioas.push(param);
     }
     #[cfg(target_os = "linux")]
     for arg in args.vfio_cdev {
         let param = serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?;
-        config.vfio_cdev.push(param);
+        spec.vfio_cdev.push(param);
     }
     #[cfg(target_os = "linux")]
     for arg in args.vfio_container {
         let param = serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?;
-        config.vfio_container.push(param);
+        spec.vfio_container.push(param);
     }
     #[cfg(target_os = "linux")]
     for arg in args.vfio_group {
         let param = serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?;
-        config.vfio_group.push(param);
+        spec.vfio_group.push(param);
     }
 
-    Ok(config)
+    Ok(spec)
 }
 
-fn create<H: Hypervisor>(hypervisor: &H, config: Config) -> Result<Machine<H>, alioth::vm::Error> {
-    let vm = Machine::new(hypervisor, config.board)?;
+fn create<H: Hypervisor>(hypervisor: &H, spec: VmSpec) -> Result<Machine<H>, alioth::vm::Error> {
+    let vm = Machine::new(hypervisor, spec.board)?;
 
     #[cfg(target_arch = "x86_64")]
     vm.add_com1()?;
@@ -361,103 +361,105 @@ fn create<H: Hypervisor>(hypervisor: &H, config: Config) -> Result<Machine<H>, a
     #[cfg(target_arch = "aarch64")]
     vm.add_pl031();
 
-    if config.pvpanic {
+    if spec.pvpanic {
         vm.add_pvpanic()?;
     }
 
     #[cfg(target_arch = "x86_64")]
-    if config.payload.firmware.is_some() {
+    if spec.payload.firmware.is_some() {
         vm.add_cmos()?;
         vm.add_fw_dbg()?;
     }
 
     #[cfg(target_arch = "x86_64")]
-    if config.payload.firmware.is_some() || !config.fw_cfg.is_empty() {
-        vm.add_fw_cfg(config.fw_cfg.into_iter())?;
+    if spec.payload.firmware.is_some() || !spec.fw_cfg.is_empty() {
+        vm.add_fw_cfg(spec.fw_cfg.into_iter())?;
     };
 
-    if let Some(param) = config.entropy {
-        vm.add_virtio_dev("virtio-entropy", param)?;
+    if let Some(entropy_spec) = spec.entropy {
+        vm.add_virtio_dev("virtio-entropy", entropy_spec)?;
     }
 
-    for (index, param) in config.net.into_iter().enumerate() {
-        match param {
+    for (index, net_spec) in spec.net.into_iter().enumerate() {
+        match net_spec {
             #[cfg(target_os = "linux")]
-            NetParam::Tap(tap_param) => vm.add_virtio_dev(format!("virtio-net-{index}"), tap_param),
+            NetSpec::Tap(tap_spec) => vm.add_virtio_dev(format!("virtio-net-{index}"), tap_spec),
             #[cfg(target_os = "linux")]
-            NetParam::Vu(sock) => {
-                let param = VuFrontendParam {
+            NetSpec::Vu(sock) => {
+                let vu_spec = VuFrontendSpec {
                     id: DeviceId::NET,
                     socket: sock.socket,
                 };
-                vm.add_virtio_dev(format!("vu-net-{index}"), param)
+                vm.add_virtio_dev(format!("vu-net-{index}"), vu_spec)
             }
             #[cfg(target_os = "macos")]
-            NetParam::Vmnet(p) => vm.add_virtio_dev(format!("virtio-net-{index}"), p),
+            NetSpec::Vmnet(vmnet_spec) => {
+                vm.add_virtio_dev(format!("virtio-net-{index}"), vmnet_spec)
+            }
         }?;
     }
 
-    for (index, param) in config.blk.into_iter().enumerate() {
-        match param {
-            BlkParam::File(p) => vm.add_virtio_dev(format!("virtio-blk-{index}"), p),
+    for (index, blk_spec) in spec.blk.into_iter().enumerate() {
+        match blk_spec {
+            BlkSpec::File(file_spec) => vm.add_virtio_dev(format!("virtio-blk-{index}"), file_spec),
             #[cfg(target_os = "linux")]
-            BlkParam::Vu(s) => {
-                let p = VuFrontendParam {
+            BlkSpec::Vu(s) => {
+                let vu_spec = VuFrontendSpec {
                     id: DeviceId::BLOCK,
                     socket: s.socket,
                 };
-                vm.add_virtio_dev(format!("vu-net-{index}"), p)
+                vm.add_virtio_dev(format!("vu-net-{index}"), vu_spec)
             }
         }?;
     }
 
-    for (index, param) in config.fs.into_iter().enumerate() {
-        match param {
-            FsParam::Dir(p) => vm.add_virtio_dev(format!("virtio-fs-{index}"), p),
+    for (index, fs_spec) in spec.fs.into_iter().enumerate() {
+        match fs_spec {
+            FsSpec::Dir(dir_spec) => vm.add_virtio_dev(format!("virtio-fs-{index}"), dir_spec),
             #[cfg(target_os = "linux")]
-            FsParam::Vu(p) => vm.add_virtio_dev(format!("vu-fs-{index}"), p),
+            FsSpec::Vu(vu_fs_spec) => vm.add_virtio_dev(format!("vu-fs-{index}"), vu_fs_spec),
         }?;
     }
 
-    if let Some(param) = config.vsock {
-        match param {
+    if let Some(vsock_spec) = spec.vsock {
+        match vsock_spec {
             #[cfg(target_os = "linux")]
-            VsockParam::Vhost(p) => vm.add_virtio_dev("vhost-vsock", p),
-            VsockParam::Uds(p) => vm.add_virtio_dev("uds-vsock", p),
+            VsockSpec::Vhost(vhost_spec) => vm.add_virtio_dev("vhost-vsock", vhost_spec),
+            VsockSpec::Uds(uds_spec) => vm.add_virtio_dev("uds-vsock", uds_spec),
             #[cfg(target_os = "linux")]
-            VsockParam::Vu(s) => {
-                let p = VuFrontendParam {
+            VsockSpec::Vu(s) => {
+                let vu_spec = VuFrontendSpec {
                     id: DeviceId::SOCKET,
                     socket: s.socket,
                 };
-                vm.add_virtio_dev("vu-vsock", p)
+                vm.add_virtio_dev("vu-vsock", vu_spec)
             }
         }?;
     }
 
-    if let Some(param) = config.balloon {
-        vm.add_virtio_dev("virtio-balloon", param)?;
+    if let Some(balloon_spec) = spec.balloon {
+        vm.add_virtio_dev("virtio-balloon", balloon_spec)?;
     }
 
     #[cfg(target_os = "linux")]
-    for param in config.vfio_ioas.into_iter() {
-        vm.add_vfio_ioas(param)?;
+    for ioas_spec in spec.vfio_ioas.into_iter() {
+        vm.add_vfio_ioas(ioas_spec)?;
     }
     #[cfg(target_os = "linux")]
-    for (index, param) in config.vfio_cdev.into_iter().enumerate() {
-        vm.add_vfio_cdev(format!("vfio-{index}").into(), param)?;
+    for (index, cdev_spec) in spec.vfio_cdev.into_iter().enumerate() {
+        vm.add_vfio_cdev(format!("vfio-{index}").into(), cdev_spec)?;
     }
 
     #[cfg(target_os = "linux")]
-    for param in config.vfio_container.into_iter() {
-        vm.add_vfio_container(param)?;
+    for container_spec in spec.vfio_container.into_iter() {
+        vm.add_vfio_container(container_spec)?;
     }
     #[cfg(target_os = "linux")]
-    for (index, param) in config.vfio_group.into_iter().enumerate() {
-        vm.add_vfio_devs_in_group(&index.to_string(), param)?;
+    for (index, group_spec) in spec.vfio_group.into_iter().enumerate() {
+        vm.add_vfio_devs_in_group(&index.to_string(), group_spec)?;
     }
 
-    vm.add_payload(config.payload);
+    vm.add_payload(spec.payload);
 
     Ok(vm)
 }
@@ -466,21 +468,21 @@ pub fn boot(mut args: BootArgs) -> Result<(), Error> {
     let object_args = mem::take(&mut args.objects);
     let objects = parse_objects(&object_args)?;
 
-    let hv_config = if let Some(arg) = args.hypervisor.take() {
+    let hv_spec = if let Some(arg) = args.hypervisor.take() {
         serde_aco::from_args(&arg, &objects).context(error::ParseArg { arg })?
     } else {
-        HvConfig::default()
+        HvSpec::default()
     };
-    let hypervisor = match hv_config {
+    let hypervisor = match hv_spec {
         #[cfg(target_os = "linux")]
-        HvConfig::Kvm(kvm_config) => Kvm::new(kvm_config).context(error::Hypervisor)?,
+        HvSpec::Kvm(kvm_spec) => Kvm::new(kvm_spec).context(error::Hypervisor)?,
         #[cfg(target_os = "macos")]
-        HvConfig::Hvf => Hvf {},
+        HvSpec::Hvf => Hvf {},
     };
 
-    let config = parse_args(args, objects)?;
+    let spec = parse_args(args, objects)?;
 
-    let vm = create(&hypervisor, config).context(error::CreateVm)?;
+    let vm = create(&hypervisor, spec).context(error::CreateVm)?;
 
     vm.boot().context(error::BootVm)?;
     vm.wait().context(error::WaitVm)?;

--- a/alioth-cli/src/boot/boot_test.rs
+++ b/alioth-cli/src/boot/boot_test.rs
@@ -15,25 +15,25 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use alioth::board::{BoardConfig, CpuConfig, CpuTopology};
+use alioth::board::{BoardSpec, CpuSpec, CpuTopology};
 #[cfg(target_arch = "x86_64")]
-use alioth::device::fw_cfg::{FwCfgContentParam, FwCfgItemParam};
+use alioth::device::fw_cfg::{FwCfgContentSpec, FwCfgItemSpec};
 use alioth::device::net::MacAddr;
-use alioth::loader::{Executable, Payload};
-use alioth::mem::{MemBackend, MemConfig};
+use alioth::loader::{Executable, PayloadSpec};
+use alioth::mem::{MemBackend, MemSpec};
 #[cfg(target_os = "linux")]
-use alioth::vfio::{CdevParam, ContainerParam, GroupParam, IoasParam};
-use alioth::virtio::dev::balloon::BalloonParam;
-use alioth::virtio::dev::blk::BlkFileParam;
-use alioth::virtio::dev::entropy::EntropyParam;
-use alioth::virtio::dev::fs::shared_dir::SharedDirParam;
+use alioth::vfio::{VfioCdevSpec, VfioContainerSpec, VfioGroupSpec, VfioIoasSpec};
+use alioth::virtio::dev::balloon::BalloonSpec;
+use alioth::virtio::dev::blk::BlkFileSpec;
+use alioth::virtio::dev::entropy::EntropySpec;
+use alioth::virtio::dev::fs::shared_dir::SharedDirSpec;
 #[cfg(target_os = "linux")]
-use alioth::virtio::dev::fs::vu::VuFsParam;
+use alioth::virtio::dev::fs::vu::VuFsSpec;
 #[cfg(target_os = "linux")]
-use alioth::virtio::dev::net::tap::NetTapParam;
+use alioth::virtio::dev::net::tap::TapNetSpec;
 #[cfg(target_os = "macos")]
-use alioth::virtio::dev::net::vmnet::NetVmnetParam;
-use alioth::virtio::dev::vsock::UdsVsockParam;
+use alioth::virtio::dev::net::vmnet::VmnetSpec;
+use alioth::virtio::dev::vsock::UdsVsockSpec;
 use alioth::virtio::worker::WorkerApi;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
@@ -43,7 +43,7 @@ use crate::boot::{
     parse_payload_arg,
 };
 
-use super::{BlkParam, Config, FsParam, NetParam, VsockParam};
+use super::{BlkSpec, FsSpec, NetSpec, VmSpec, VsockSpec};
 
 #[test]
 fn test_parse_args() {
@@ -96,10 +96,10 @@ fn test_parse_args() {
         #[cfg(target_os = "linux")]
         ("id_gpus", "0000:06:0d.0,0000:06:0d.1"),
     ]);
-    let config = parse_args(args, objects).unwrap();
-    let want = Config {
-        board: BoardConfig {
-            cpu: CpuConfig {
+    let spec = parse_args(args, objects).unwrap();
+    let want = VmSpec {
+        board: BoardSpec {
+            cpu: CpuSpec {
                 count: 16,
                 topology: CpuTopology {
                     smt: true,
@@ -107,7 +107,7 @@ fn test_parse_args() {
                     sockets: 1,
                 },
             },
-            mem: MemConfig {
+            mem: MemSpec {
                 size: 128 << 30,
                 backend: MemBackend::Anonymous,
                 shared: true,
@@ -116,7 +116,7 @@ fn test_parse_args() {
             },
             coco: None,
         },
-        payload: Payload {
+        payload: PayloadSpec {
             executable: Some(Executable::Linux(Path::new("vmlinuz").into())),
             initramfs: Some(Path::new("initramfs.cpio").into()),
             cmdline: Some("console=ttyS0".into()),
@@ -124,14 +124,14 @@ fn test_parse_args() {
         },
         net: vec![
             #[cfg(target_os = "linux")]
-            NetParam::Tap(NetTapParam {
+            NetSpec::Tap(TapNetSpec {
                 mac: MacAddr([0x02, 0x32, 0x10, 0xd0, 0x00, 0x01]),
                 mtu: 1500,
                 tap: Some(Path::new("/dev/tap86").into()),
                 ..Default::default()
             }),
             #[cfg(target_os = "linux")]
-            NetParam::Tap(NetTapParam {
+            NetSpec::Tap(TapNetSpec {
                 mac: MacAddr([0xea, 0xc2, 0x14, 0x80, 0x10, 0x01]),
                 mtu: 1500,
                 if_name: Some("tap1".into()),
@@ -140,88 +140,88 @@ fn test_parse_args() {
                 ..Default::default()
             }),
             #[cfg(target_os = "macos")]
-            NetParam::Vmnet(NetVmnetParam {
+            NetSpec::Vmnet(VmnetSpec {
                 mac: Some(MacAddr([0xa0, 0xd0, 0xea, 0x8a, 0xd3, 0x37])),
             }),
         ],
         blk: vec![
-            BlkParam::File(BlkFileParam {
+            BlkSpec::File(BlkFileSpec {
                 path: Path::new("ubuntu-25.04-server-cloudimg.raw").into(),
                 readonly: false,
                 api: WorkerApi::Mio,
             }),
-            BlkParam::File(BlkFileParam {
+            BlkSpec::File(BlkFileSpec {
                 path: Path::new("cloudinit.img").into(),
                 readonly: true,
                 api: WorkerApi::Mio,
             }),
         ],
         fs: vec![
-            FsParam::Dir(SharedDirParam {
+            FsSpec::Dir(SharedDirSpec {
                 path: Path::new("/home").into(),
                 tag: "home".into(),
                 dax_window: 1 << 30,
             }),
             #[cfg(target_os = "linux")]
-            FsParam::Vu(VuFsParam {
+            FsSpec::Vu(VuFsSpec {
                 socket: Path::new("fs.vsock").into(),
                 tag: Some("vufs".into()),
                 dax_window: 0,
             }),
         ],
-        vsock: Some(VsockParam::Uds(UdsVsockParam {
+        vsock: Some(VsockSpec::Uds(UdsVsockSpec {
             cid: 3,
             path: Path::new("vsock_3.sock").into(),
         })),
-        entropy: Some(EntropyParam::default()),
-        balloon: Some(BalloonParam {
+        entropy: Some(EntropySpec::default()),
+        balloon: Some(BalloonSpec {
             free_page_reporting: true,
         }),
         pvpanic: true,
         #[cfg(target_arch = "x86_64")]
         fw_cfg: vec![
-            FwCfgItemParam {
+            FwCfgItemSpec {
                 name: "item1".into(),
-                content: FwCfgContentParam::File(Path::new("file1").into()),
+                content: FwCfgContentSpec::File(Path::new("file1").into()),
             },
-            FwCfgItemParam {
+            FwCfgItemSpec {
                 name: "item2".into(),
-                content: FwCfgContentParam::String("string2".into()),
+                content: FwCfgContentSpec::String("string2".into()),
             },
         ],
         #[cfg(target_os = "linux")]
-        vfio_cdev: vec![CdevParam {
+        vfio_cdev: vec![VfioCdevSpec {
             path: Path::new("/dev/vfio/devices/vfio0").into(),
             ioas: Some("default".into()),
         }],
         #[cfg(target_os = "linux")]
-        vfio_ioas: vec![IoasParam {
+        vfio_ioas: vec![VfioIoasSpec {
             name: "default".into(),
             dev_iommu: Some(Path::new("/dev/iommu").into()),
         }],
         #[cfg(target_os = "linux")]
-        vfio_container: vec![ContainerParam {
+        vfio_container: vec![VfioContainerSpec {
             name: "gpu_container".into(),
             dev_vfio: Some(Path::new("/dev/vfio/vfio").into()),
         }],
         #[cfg(target_os = "linux")]
-        vfio_group: vec![GroupParam {
+        vfio_group: vec![VfioGroupSpec {
             path: Path::new("/dev/vfio/26").into(),
             container: Some("gpu_container".into()),
             devices: vec!["0000:06:0d.0".into(), "0000:06:0d.1".into()],
         }],
     };
-    assert_eq!(config, want);
+    assert_eq!(spec, want);
 }
 
 #[rstest]
 #[cfg_attr(target_os = "macos", case(
     "vmnet",
-    NetParam::Vmnet(NetVmnetParam { mac: None })
+    NetSpec::Vmnet(VmnetSpec { mac: None })
 ))]
 #[cfg_attr(target_os = "linux", case(
     "tap,tap=/dev/tap86,mac=02:32:10:d0:00:01,mtu=1500,api=iouring",
-    NetParam::Tap(NetTapParam {
+    NetSpec::Tap(TapNetSpec {
         mac: MacAddr([0x02, 0x32, 0x10, 0xd0, 0x00, 0x01]),
         mtu: 1500,
         tap: Some(Path::new("/dev/tap86").into()),
@@ -229,7 +229,7 @@ fn test_parse_args() {
         ..Default::default()
     }),
 ))]
-fn test_parse_net_arg(#[case] arg: &str, #[case] want: NetParam) {
+fn test_parse_net_arg(#[case] arg: &str, #[case] want: NetSpec) {
     let objects = HashMap::new();
     assert_eq!(parse_net_arg(arg, &objects).unwrap(), want);
 }
@@ -239,7 +239,7 @@ fn test_parse_net_arg(#[case] arg: &str, #[case] want: NetParam) {
     Some("count=16,topology=id_topo".into()),
     0,
     HashMap::from([("id_topo", "cores=8,sockets=2,smt=false")]),
-    CpuConfig {
+    CpuSpec {
         count: 16,
         topology: CpuTopology { smt: false, cores: 8, sockets: 2 },
     }
@@ -248,7 +248,7 @@ fn test_parse_net_arg(#[case] arg: &str, #[case] want: NetParam) {
     None,
     16,
     HashMap::new(),
-    CpuConfig {
+    CpuSpec {
         count: 16,
         topology: CpuTopology { smt: false, cores: 16, sockets: 1 }
     }
@@ -257,7 +257,7 @@ fn test_parse_cpu_arg(
     #[case] arg: Option<Box<str>>,
     #[case] num_cpu: u16,
     #[case] objects: HashMap<&str, &str>,
-    #[case] want: CpuConfig,
+    #[case] want: CpuSpec,
 ) {
     assert_eq!(parse_cpu_arg(arg, num_cpu, &objects).unwrap(), want,);
 }
@@ -266,7 +266,7 @@ fn test_parse_cpu_arg(
 #[case(
     None,
     "32G",
-    MemConfig {
+    MemSpec {
         size: 32 << 30,
         #[cfg(target_os = "linux")]
         backend: MemBackend::Memfd,
@@ -278,21 +278,17 @@ fn test_parse_cpu_arg(
 #[cfg_attr(target_os = "linux", case(
     Some("size=32g,backend=memfd,shared=true,thp=true".into()),
     "",
-    MemConfig {
+    MemSpec {
         size: 32 << 30,
         backend: MemBackend::Memfd,
         shared: true,
         transparent_hugepage: true
     }
 ))]
-fn test_parse_mem_arg(
-    #[case] arg: Option<String>,
-    #[case] mem_size: &str,
-    #[case] want: MemConfig,
-) {
+fn test_parse_mem_arg(#[case] arg: Option<String>, #[case] mem_size: &str, #[case] want: MemSpec) {
     let objects = HashMap::new();
-    let config = parse_mem_arg(arg, mem_size.to_owned(), &objects).unwrap();
-    assert_eq!(config, want);
+    let spec = parse_mem_arg(arg, mem_size.to_owned(), &objects).unwrap();
+    assert_eq!(spec, want);
 }
 
 #[rstest]
@@ -303,7 +299,7 @@ fn test_parse_mem_arg(
         initramfs: Some(Path::new("initramfs.cpio").into()),
         ..Default::default()
     },
-    Payload {
+    PayloadSpec {
         firmware: None,
         initramfs: Some(Path::new("initramfs.cpio").into()),
         executable: Some(Executable::Linux(Path::new("vmlinuz").into())),
@@ -317,21 +313,21 @@ fn test_parse_mem_arg(
         initramfs: Some(Path::new("initramfs.cpio").into()),
         ..Default::default()
     },
-    Payload {
+    PayloadSpec {
         firmware: None,
         initramfs: Some(Path::new("initramfs.cpio").into()),
         executable: Some(Executable::Pvh(Path::new("vmlinux.bin").into())),
         cmdline: Some("console=ttyS0".into()),
     }
 ))]
-fn test_parse_payload_arg(#[case] mut args: BootArgs, #[case] want: Payload) {
+fn test_parse_payload_arg(#[case] mut args: BootArgs, #[case] want: PayloadSpec) {
     assert_eq!(parse_payload_arg(&mut args), want);
 }
 
 #[rstest]
 #[case(
     "file,path=ubuntu-25.04-server-cloudimg.raw",
-    BlkParam::File(BlkFileParam {
+    BlkSpec::File(BlkFileSpec {
         path: Path::new("ubuntu-25.04-server-cloudimg.raw").into(),
         readonly: false,
         api: WorkerApi::Mio
@@ -339,7 +335,7 @@ fn test_parse_payload_arg(#[case] mut args: BootArgs, #[case] want: Payload) {
 )]
 #[case(
     "path=cloudinit.img,readonly=true",
-    BlkParam::File(BlkFileParam {
+    BlkSpec::File(BlkFileSpec {
         path: Path::new("cloudinit.img").into(),
         readonly: true,
         api: WorkerApi::Mio
@@ -347,7 +343,7 @@ fn test_parse_payload_arg(#[case] mut args: BootArgs, #[case] want: Payload) {
 )]
 #[case(
     "ubuntu-25.04-server-cloudimg.raw",
-    BlkParam::File(BlkFileParam {
+    BlkSpec::File(BlkFileSpec {
         path: Path::new("ubuntu-25.04-server-cloudimg.raw").into(),
         readonly: false,
         api: WorkerApi::Mio
@@ -355,13 +351,13 @@ fn test_parse_payload_arg(#[case] mut args: BootArgs, #[case] want: Payload) {
 )]
 #[cfg_attr(target_os = "linux", case(
     "file,path=ubuntu-25.04-server-cloudimg.raw,api=io_uring",
-    BlkParam::File(BlkFileParam {
+    BlkSpec::File(BlkFileSpec {
         path: Path::new("ubuntu-25.04-server-cloudimg.raw").into(),
         readonly: false,
         api: WorkerApi::IoUring
     })
 ))]
-fn test_parse_blk_arg(#[case] arg: &str, #[case] want: BlkParam) {
+fn test_parse_blk_arg(#[case] arg: &str, #[case] want: BlkSpec) {
     let objects = HashMap::new();
     assert_eq!(parse_blk_arg(arg, &objects), want);
 }

--- a/alioth-cli/src/boot/config.rs
+++ b/alioth-cli/src/boot/config.rs
@@ -15,21 +15,21 @@
 #[cfg(target_os = "linux")]
 use std::path::Path;
 
-use alioth::board::BoardConfig;
+use alioth::board::BoardSpec;
 #[cfg(target_arch = "x86_64")]
-use alioth::device::fw_cfg::FwCfgItemParam;
-use alioth::loader::Payload;
+use alioth::device::fw_cfg::FwCfgItemSpec;
+use alioth::loader::PayloadSpec;
 #[cfg(target_os = "linux")]
-use alioth::vfio::{CdevParam, ContainerParam, GroupParam, IoasParam};
-use alioth::virtio::dev::balloon::BalloonParam;
-use alioth::virtio::dev::blk::BlkFileParam;
-use alioth::virtio::dev::entropy::EntropyParam;
-use alioth::virtio::dev::fs::shared_dir::SharedDirParam;
+use alioth::vfio::{VfioCdevSpec, VfioContainerSpec, VfioGroupSpec, VfioIoasSpec};
+use alioth::virtio::dev::balloon::BalloonSpec;
+use alioth::virtio::dev::blk::BlkFileSpec;
+use alioth::virtio::dev::entropy::EntropySpec;
+use alioth::virtio::dev::fs::shared_dir::SharedDirSpec;
 #[cfg(target_os = "macos")]
-use alioth::virtio::dev::net::vmnet::NetVmnetParam;
-use alioth::virtio::dev::vsock::UdsVsockParam;
+use alioth::virtio::dev::net::vmnet::VmnetSpec;
+use alioth::virtio::dev::vsock::UdsVsockSpec;
 #[cfg(target_os = "linux")]
-use alioth::virtio::dev::{fs::vu::VuFsParam, net::tap::NetTapParam, vsock::VhostVsockParam};
+use alioth::virtio::dev::{fs::vu::VuFsSpec, net::tap::TapNetSpec, vsock::VhostVsockSpec};
 use serde::Deserialize;
 use serde_aco::Help;
 
@@ -40,15 +40,15 @@ pub struct VuSocket {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Help)]
-pub enum NetParam {
+pub enum NetSpec {
     /// VirtIO net device backed by TUN/TAP, MacVTap, or IPVTap.
     #[cfg(target_os = "linux")]
     #[serde(alias = "tap")]
-    Tap(NetTapParam),
+    Tap(TapNetSpec),
     /// VirtIO net device backed by vmnet framework.
     #[cfg(target_os = "macos")]
     #[serde(alias = "vmnet")]
-    Vmnet(NetVmnetParam),
+    Vmnet(VmnetSpec),
     /// vhost-user net device over a Unix domain socket.
     #[cfg(target_os = "linux")]
     #[serde(alias = "vu")]
@@ -56,10 +56,10 @@ pub enum NetParam {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Help)]
-pub enum BlkParam {
+pub enum BlkSpec {
     /// VirtIO block device backed a disk image file.
     #[serde(alias = "file")]
-    File(BlkFileParam),
+    File(BlkFileSpec),
     #[cfg(target_os = "linux")]
     #[serde(alias = "vu")]
     /// vhost-user block device over a Unix domain socket.
@@ -67,25 +67,25 @@ pub enum BlkParam {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Clone, Help)]
-pub enum FsParam {
+pub enum FsSpec {
     /// VirtIO FS device backed by a shared directory.
     #[serde(alias = "dir")]
-    Dir(SharedDirParam),
+    Dir(SharedDirSpec),
     #[cfg(target_os = "linux")]
     /// VirtIO FS device backed by a vhost-user process, e.g. virtiofsd.
     #[serde(alias = "vu")]
-    Vu(VuFsParam),
+    Vu(VuFsSpec),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Help)]
-pub enum VsockParam {
+pub enum VsockSpec {
     #[cfg(target_os = "linux")]
     /// Vsock device backed by host kernel vhost-vsock module.
     #[serde(alias = "vhost")]
-    Vhost(VhostVsockParam),
+    Vhost(VhostVsockSpec),
     /// Vsock device mapped to a Unix domain socket.
     #[serde(alias = "uds")]
-    Uds(UdsVsockParam),
+    Uds(UdsVsockSpec),
     #[cfg(target_os = "linux")]
     /// Vsock device backed by a vhost-user process.
     #[serde(alias = "vu")]
@@ -93,28 +93,28 @@ pub enum VsockParam {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Deserialize)]
-pub struct Config {
-    pub board: BoardConfig,
+pub struct VmSpec {
+    pub board: BoardSpec,
 
-    pub payload: Payload,
+    pub payload: PayloadSpec,
 
-    pub net: Vec<NetParam>,
-    pub blk: Vec<BlkParam>,
-    pub fs: Vec<FsParam>,
-    pub vsock: Option<VsockParam>,
-    pub entropy: Option<EntropyParam>,
-    pub balloon: Option<BalloonParam>,
+    pub net: Vec<NetSpec>,
+    pub blk: Vec<BlkSpec>,
+    pub fs: Vec<FsSpec>,
+    pub vsock: Option<VsockSpec>,
+    pub entropy: Option<EntropySpec>,
+    pub balloon: Option<BalloonSpec>,
     pub pvpanic: bool,
 
     #[cfg(target_arch = "x86_64")]
-    pub fw_cfg: Vec<FwCfgItemParam>,
+    pub fw_cfg: Vec<FwCfgItemSpec>,
 
     #[cfg(target_os = "linux")]
-    pub vfio_cdev: Vec<CdevParam>,
+    pub vfio_cdev: Vec<VfioCdevSpec>,
     #[cfg(target_os = "linux")]
-    pub vfio_ioas: Vec<IoasParam>,
+    pub vfio_ioas: Vec<VfioIoasSpec>,
     #[cfg(target_os = "linux")]
-    pub vfio_group: Vec<GroupParam>,
+    pub vfio_group: Vec<VfioGroupSpec>,
     #[cfg(target_os = "linux")]
-    pub vfio_container: Vec<ContainerParam>,
+    pub vfio_container: Vec<VfioContainerSpec>,
 }

--- a/alioth-cli/src/vu.rs
+++ b/alioth-cli/src/vu.rs
@@ -19,11 +19,11 @@ use std::sync::Arc;
 
 use alioth::errors::{DebugTrace, trace_error};
 use alioth::mem::mapped::RamBus;
-use alioth::virtio::dev::blk::BlkFileParam;
-use alioth::virtio::dev::fs::shared_dir::SharedDirParam;
-use alioth::virtio::dev::net::tap::NetTapParam;
-use alioth::virtio::dev::vsock::UdsVsockParam;
-use alioth::virtio::dev::{DevParam, Virtio, VirtioDevice};
+use alioth::virtio::dev::blk::BlkFileSpec;
+use alioth::virtio::dev::fs::shared_dir::SharedDirSpec;
+use alioth::virtio::dev::net::tap::TapNetSpec;
+use alioth::virtio::dev::vsock::UdsVsockSpec;
+use alioth::virtio::dev::{DevSpec, Virtio, VirtioDevice};
 use alioth::virtio::vu::backend::{VuBackend, VuEventfd, VuIrqSender};
 use clap::{Args, Subcommand};
 use serde::Deserialize;
@@ -84,13 +84,13 @@ where
 #[derive(Subcommand, Debug, Clone)]
 pub enum DevType {
     /// VirtIO net device backed by TUN/TAP, MacVTap, or IPVTap.
-    Net(DevArgs<NetTapParam>),
+    Net(DevArgs<TapNetSpec>),
     /// VirtIO block device backed by a file.
-    Blk(DevArgs<BlkFileParam>),
+    Blk(DevArgs<BlkFileSpec>),
     /// VirtIO filesystem device backed by a shared host directory.
-    Fs(DevArgs<SharedDirParam>),
+    Fs(DevArgs<SharedDirSpec>),
     /// VirtIO vsock device backed by a Unix domain socket.
-    Vsock(DevArgs<UdsVsockParam>),
+    Vsock(DevArgs<UdsVsockSpec>),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -111,7 +111,7 @@ fn create_dev<D, P>(
 ) -> Result<VirtioDevice<VuIrqSender, VuEventfd>, Error>
 where
     D: Virtio,
-    P: DevParam<Device = D> + Help + for<'a> Deserialize<'a> + Send + Sync + 'static,
+    P: DevSpec<Device = D> + Help + for<'a> Deserialize<'a> + Send + Sync + 'static,
 {
     let name: Arc<str> = name.into();
     let objects = parse_objects(&args.objects)?;

--- a/alioth/src/board/board.rs
+++ b/alioth/src/board/board.rs
@@ -43,10 +43,10 @@ use crate::device::MmioDev;
 #[cfg(target_arch = "x86_64")]
 use crate::device::fw_cfg::FwCfg;
 use crate::errors::{DebugTrace, trace_error};
-use crate::hv::{Coco, Hypervisor, Vm, VmConfig};
-use crate::loader::Payload;
+use crate::hv::{CocoSpec, Hypervisor, Vm, VmSpec};
+use crate::loader::PayloadSpec;
 use crate::mem::mapped::ArcMemPages;
-use crate::mem::{MemBackend, MemConfig, MemRegion, MemRegionType, Memory};
+use crate::mem::{MemBackend, MemRegion, MemRegionType, MemSpec, Memory};
 use crate::pci::bus::PciBus;
 
 #[cfg(target_arch = "aarch64")]
@@ -106,7 +106,7 @@ const fn default_cpu_count() -> u16 {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Deserialize, Help)]
-pub struct CpuConfig {
+pub struct CpuSpec {
     /// Number of VCPUs assigned to the guest. [default: 1]
     #[serde(default = "default_cpu_count")]
     pub count: u16,
@@ -115,7 +115,7 @@ pub struct CpuConfig {
     pub topology: CpuTopology,
 }
 
-impl CpuConfig {
+impl CpuSpec {
     pub fn validate(&self) -> bool {
         let vcpus_per_core = 1 + self.topology.smt as u16;
         let vcpus_per_socket = self.topology.cores * vcpus_per_core;
@@ -127,13 +127,13 @@ impl CpuConfig {
 pub const PCIE_MMIO_64_SIZE: u64 = 1 << 40;
 
 #[derive(Debug, Default, PartialEq, Eq, Deserialize)]
-pub struct BoardConfig {
-    pub mem: MemConfig,
-    pub cpu: CpuConfig,
-    pub coco: Option<Coco>,
+pub struct BoardSpec {
+    pub mem: MemSpec,
+    pub cpu: CpuSpec,
+    pub coco: Option<CocoSpec>,
 }
 
-impl BoardConfig {
+impl BoardSpec {
     pub fn pcie_mmio_64_start(&self) -> u64 {
         (self.mem.size.saturating_sub(RAM_32_SIZE) + MEM_64_START).next_power_of_two()
     }
@@ -153,8 +153,8 @@ where
     pub vm: V,
     pub memory: Memory,
     pub arch: ArchBoard<V>,
-    pub config: BoardConfig,
-    pub payload: RwLock<Option<Payload>>,
+    pub spec: BoardSpec,
+    pub payload: RwLock<Option<PayloadSpec>>,
     pub io_devs: RwLock<Vec<(u16, Arc<dyn MmioDev>)>>,
     pub mmio_devs: RwLock<Vec<(u64, Arc<dyn MmioDev>)>>,
     pub pci_bus: PciBus,
@@ -166,24 +166,24 @@ impl<V> Board<V>
 where
     V: Vm,
 {
-    pub fn new<H>(hv: &H, config: BoardConfig) -> Result<Self>
+    pub fn new<H>(hv: &H, spec: BoardSpec) -> Result<Self>
     where
         H: Hypervisor<Vm = V>,
     {
-        config.validate()?;
+        spec.validate()?;
 
-        let vm_config = VmConfig {
-            coco: config.coco.clone(),
+        let vm_spec = VmSpec {
+            coco: spec.coco.clone(),
         };
-        let mut vm = hv.create_vm(&vm_config)?;
+        let mut vm = hv.create_vm(&vm_spec)?;
         let vm_memory = Arc::new(vm.create_vm_memory()?);
-        let arch = ArchBoard::new(hv, &vm, &config)?;
+        let arch = ArchBoard::new(hv, &vm, &spec)?;
 
         let board = Board {
             vm,
             memory: Memory::new(vm_memory.clone()),
             arch,
-            config,
+            spec,
             payload: RwLock::new(None),
             io_devs: RwLock::new(Vec::new()),
             mmio_devs: RwLock::new(Vec::new()),
@@ -208,7 +208,7 @@ where
                 MemRegionType::Reserved,
             )),
         )?;
-        let pcie_mmio_64_start = self.config.pcie_mmio_64_start();
+        let pcie_mmio_64_start = self.spec.pcie_mmio_64_start();
         self.pci_bus.segment.assign_resources(&[
             (0x1000, 0x10000),
             (
@@ -240,18 +240,18 @@ where
         size: u64,
         #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] name: &CStr,
     ) -> Result<ArcMemPages> {
-        let mmap_flag = if self.config.mem.shared {
+        let mmap_flag = if self.spec.mem.shared {
             Some(MAP_SHARED)
         } else {
             Some(MAP_PRIVATE)
         };
-        let pages = match self.config.mem.backend {
+        let pages = match self.spec.mem.backend {
             #[cfg(target_os = "linux")]
             MemBackend::Memfd => ArcMemPages::from_memfd(name, size as usize, None),
             MemBackend::Anonymous => ArcMemPages::from_anonymous(size as usize, None, mmap_flag),
         }?;
         #[cfg(target_os = "linux")]
-        if self.config.mem.transparent_hugepage {
+        if self.spec.mem.transparent_hugepage {
             pages.madvise_hugepage()?;
         }
         Ok(pages)

--- a/alioth/src/board/board_amd64/board_amd64.rs
+++ b/alioth/src/board/board_amd64/board_amd64.rs
@@ -30,7 +30,7 @@ use crate::arch::layout::{
     BIOS_DATA_END, EBDA_END, EBDA_START, IOAPIC_START, MEM_64_START, PORT_ACPI_RESET,
     PORT_ACPI_SLEEP_CONTROL, PORT_ACPI_TIMER, RAM_32_SIZE,
 };
-use crate::board::{Board, BoardConfig, CpuTopology, PCIE_MMIO_64_SIZE, Result, error};
+use crate::board::{Board, BoardSpec, CpuTopology, PCIE_MMIO_64_SIZE, Result, error};
 use crate::device::ioapic::IoApic;
 use crate::firmware::acpi::bindings::{
     AcpiTableFadt, AcpiTableHeader, AcpiTableRsdp, AcpiTableXsdt3,
@@ -39,8 +39,8 @@ use crate::firmware::acpi::reg::{AcpiPmTimer, FadtReset, FadtSleepControl};
 use crate::firmware::acpi::{
     AcpiTable, create_fadt, create_madt, create_mcfg, create_rsdp, create_xsdt,
 };
-use crate::hv::{Coco, Hypervisor, Vm};
-use crate::loader::{Executable, InitState, Payload};
+use crate::hv::{CocoSpec, Hypervisor, Vm};
+use crate::loader::{Executable, InitState, PayloadSpec};
 use crate::mem::{MemRange, MemRegion, MemRegionEntry, MemRegionType};
 use crate::utils::wrapping_sum;
 
@@ -71,14 +71,14 @@ fn add_topology(cpuids: &mut HashMap<CpuidIn, CpuidResult>, func: u32, levels: &
 }
 
 impl<V: Vm> ArchBoard<V> {
-    pub fn new<H>(hv: &H, vm: &V, config: &BoardConfig) -> Result<Self>
+    pub fn new<H>(hv: &H, vm: &V, spec: &BoardSpec) -> Result<Self>
     where
         H: Hypervisor<Vm = V>,
     {
-        let mut cpuids = hv.get_supported_cpuids(config.coco.as_ref())?;
+        let mut cpuids = hv.get_supported_cpuids(spec.coco.as_ref())?;
 
-        let threads_per_core = 1 + config.cpu.topology.smt as u16;
-        let threads_per_socket = config.cpu.topology.cores * threads_per_core;
+        let threads_per_core = 1 + spec.cpu.topology.smt as u16;
+        let threads_per_socket = spec.cpu.topology.cores * threads_per_core;
 
         add_topology(
             &mut cpuids,
@@ -138,8 +138,8 @@ impl<V: Vm> ArchBoard<V> {
             cpuids.insert(CpuidIn { func, index: None }, host_cpuid);
         }
 
-        if let Some(coco) = &config.coco
-            && matches!(coco, Coco::AmdSev { .. } | Coco::AmdSnp { .. })
+        if let Some(coco) = &spec.coco
+            && matches!(coco, CocoSpec::AmdSev { .. } | CocoSpec::AmdSnp { .. })
         {
             sev::adjust_cpuid(coco, &mut cpuids)?;
         }
@@ -170,10 +170,10 @@ where
     V: Vm,
 {
     pub fn encode_cpu_identity(&self, index: u16) -> u64 {
-        encode_x2apic_id(&self.config.cpu.topology, index) as u64
+        encode_x2apic_id(&self.spec.cpu.topology, index) as u64
     }
 
-    pub(crate) fn setup_fw_cfg(&self, payload: &Payload) -> Result<()> {
+    pub(crate) fn setup_fw_cfg(&self, payload: &PayloadSpec) -> Result<()> {
         let Some(dev) = &*self.fw_cfg.lock() else {
             return Ok(());
         };
@@ -191,14 +191,14 @@ where
     }
 
     pub fn create_ram(&self) -> Result<()> {
-        let config = &self.config;
+        let spec = &self.spec;
         let memory = &self.memory;
 
-        let low_mem_size = std::cmp::min(config.mem.size, RAM_32_SIZE);
+        let low_mem_size = std::cmp::min(spec.mem.size, RAM_32_SIZE);
         let pages_low = self.create_ram_pages(low_mem_size, c"ram-low")?;
         let region_low = MemRegion {
             ranges: vec![MemRange::Ram(pages_low.clone())],
-            entries: if self.config.coco.is_none() {
+            entries: if self.spec.coco.is_none() {
                 vec![
                     MemRegionEntry {
                         size: BIOS_DATA_END,
@@ -227,8 +227,8 @@ where
         };
         memory.add_region(0, Arc::new(region_low))?;
 
-        if config.mem.size > RAM_32_SIZE {
-            let mem_hi_size = config.mem.size - RAM_32_SIZE;
+        if spec.mem.size > RAM_32_SIZE {
+            let mem_hi_size = spec.mem.size - RAM_32_SIZE;
             let mem_hi = self.create_ram_pages(mem_hi_size, c"ram-high")?;
             let region_hi = MemRegion::with_ram(mem_hi.clone(), MemRegionType::Ram);
             memory.add_region(MEM_64_START, Arc::new(region_hi))?;
@@ -237,19 +237,19 @@ where
     }
 
     pub fn coco_init(&self, memory: Arc<V::Memory>) -> Result<()> {
-        let Some(coco) = &self.config.coco else {
+        let Some(coco) = &self.spec.coco else {
             return Ok(());
         };
         match coco {
-            Coco::AmdSev { policy } => self.sev_init(*policy, memory)?,
-            Coco::AmdSnp { policy } => self.snp_init(*policy, memory)?,
-            Coco::IntelTdx { attr } => self.tdx_init(*attr, memory)?,
+            CocoSpec::AmdSev { policy } => self.sev_init(*policy, memory)?,
+            CocoSpec::AmdSnp { policy } => self.snp_init(*policy, memory)?,
+            CocoSpec::IntelTdx { attr } => self.tdx_init(*attr, memory)?,
         }
         Ok(())
     }
 
     fn patch_dsdt(&self, data: &mut [u8; 352]) {
-        let pcie_mmio_64_start = self.config.pcie_mmio_64_start();
+        let pcie_mmio_64_start = self.spec.pcie_mmio_64_start();
         let pcei_mmio_64_max = pcie_mmio_64_start - 1 + PCIE_MMIO_64_SIZE;
         data[DSDT_OFFSET_PCI_QWORD_MEM..(DSDT_OFFSET_PCI_QWORD_MEM + 8)]
             .copy_from_slice(&pcie_mmio_64_start.to_le_bytes());
@@ -284,7 +284,7 @@ where
 
         let offset_madt = offset_fadt + size_of_val(&fadt);
         debug_assert_eq!(offset_madt % 4, 0);
-        let apic_ids: Vec<u32> = (0..self.config.cpu.count)
+        let apic_ids: Vec<u32> = (0..self.spec.cpu.count)
             .map(|index| self.encode_cpu_identity(index) as u32)
             .collect();
         let (madt, madt_ioapic, madt_apics) = create_madt(&apic_ids);
@@ -324,7 +324,7 @@ where
         memory.add_io_dev(PORT_ACPI_RESET, Arc::new(FadtReset))?;
         memory.add_io_dev(PORT_ACPI_SLEEP_CONTROL, Arc::new(FadtSleepControl))?;
         memory.add_io_dev(PORT_ACPI_TIMER, Arc::new(AcpiPmTimer::new()))?;
-        if self.config.coco.is_none() {
+        if self.spec.coco.is_none() {
             let ram = memory.ram_bus();
             acpi_table.relocate(EBDA_START + size_of::<AcpiTableRsdp>() as u64);
             acpi_table.update_checksums();
@@ -344,8 +344,8 @@ where
             dev.add_acpi(acpi_table).context(error::FwCfg)?;
             let mem_regions = memory.mem_region_entries();
             dev.add_e820(&mem_regions).context(error::FwCfg)?;
-            dev.add_ram_size(self.config.mem.size);
-            dev.add_cpu_count(self.config.cpu.count);
+            dev.add_ram_size(self.spec.mem.size);
+            dev.add_cpu_count(self.spec.cpu.count);
         }
         Ok(())
     }

--- a/alioth/src/board/board_amd64/sev.rs
+++ b/alioth/src/board/board_amd64/sev.rs
@@ -22,11 +22,11 @@ use crate::arch::cpuid::{
 };
 use crate::arch::sev::{SevPolicy, SnpPolicy};
 use crate::board::{Board, Result, error};
-use crate::hv::{Coco, Vm, VmMemory};
+use crate::hv::{CocoSpec, Vm, VmMemory};
 use crate::mem::mapped::ArcMemPages;
 use crate::mem::{self, LayoutChanged, MarkPrivateMemory};
 
-pub fn adjust_cpuid(coco: &Coco, cpuids: &mut HashMap<CpuidIn, CpuidResult>) -> Result<()> {
+pub fn adjust_cpuid(coco: &CocoSpec, cpuids: &mut HashMap<CpuidIn, CpuidResult>) -> Result<()> {
     // AMD Volume 3, section E.4.17.
     let in_ = CpuidIn {
         func: 0x8000_001f,
@@ -39,17 +39,17 @@ pub fn adjust_cpuid(coco: &Coco, cpuids: &mut HashMap<CpuidIn, CpuidResult>) -> 
     out.ebx = CpuidExt1fEbx::new(host_ebx.cbit_pos(), 1, 0).0;
     out.ecx = 0;
     out.edx = 0;
-    if let Coco::AmdSev { policy } = coco {
+    if let CocoSpec::AmdSev { policy } = coco {
         out.eax = if policy.es() {
             (CpuidExt1fEAx::SEV | CpuidExt1fEAx::SEV_ES).bits()
         } else {
             CpuidExt1fEAx::SEV.bits()
         };
-    } else if let Coco::AmdSnp { .. } = coco {
+    } else if let CocoSpec::AmdSnp { .. } = coco {
         out.eax = (CpuidExt1fEAx::SEV | CpuidExt1fEAx::SEV_ES | CpuidExt1fEAx::SEV_SNP).bits()
     }
 
-    if let Coco::AmdSnp { .. } = coco {
+    if let CocoSpec::AmdSnp { .. } = coco {
         snp_adjust_cpuids(cpuids);
     }
 

--- a/alioth/src/board/board_arm64.rs
+++ b/alioth/src/board/board_arm64.rs
@@ -23,7 +23,7 @@ use crate::arch::layout::{
     RAM_32_SIZE, RAM_32_START,
 };
 use crate::arch::reg::MpidrEl1;
-use crate::board::{Board, BoardConfig, CpuTopology, PCIE_MMIO_64_SIZE, Result};
+use crate::board::{Board, BoardSpec, CpuTopology, PCIE_MMIO_64_SIZE, Result};
 use crate::firmware::dt::{DeviceTree, Node, PropVal};
 use crate::hv::{GicV2, GicV2m, GicV3, Hypervisor, Its, Vm};
 use crate::loader::{Executable, InitState};
@@ -54,11 +54,11 @@ where
 }
 
 impl<V: Vm> ArchBoard<V> {
-    pub fn new<H>(_hv: &H, vm: &V, config: &BoardConfig) -> Result<Self>
+    pub fn new<H>(_hv: &H, vm: &V, spec: &BoardSpec) -> Result<Self>
     where
         H: Hypervisor<Vm = V>,
     {
-        let gic = match vm.create_gic_v3(GIC_DIST_START, GIC_V3_REDIST_START, config.cpu.count) {
+        let gic = match vm.create_gic_v3(GIC_DIST_START, GIC_V3_REDIST_START, spec.cpu.count) {
             Ok(v3) => Gic::V3(v3),
             Err(e) => {
                 log::error!("Cannot create GIC v3: {e:?}trying v2...");
@@ -104,11 +104,11 @@ where
     V: Vm,
 {
     pub fn encode_cpu_identity(&self, index: u16) -> u64 {
-        encode_mpidr(&self.config.cpu.topology, index).0
+        encode_mpidr(&self.spec.cpu.topology, index).0
     }
 
     pub fn create_ram(&self) -> Result<()> {
-        let mem_size = self.config.mem.size;
+        let mem_size = self.spec.mem.size;
         let memory = &self.memory;
 
         let low_mem_size = std::cmp::min(mem_size, RAM_32_SIZE);
@@ -193,7 +193,7 @@ where
     }
 
     pub fn create_cpu_nodes(&self, root: &mut Node) {
-        let topology = &self.config.cpu.topology;
+        let topology = &self.spec.cpu.topology;
 
         let thread_node = |socket_id: u8, core_id: u16, thread_id: u8| {
             let phandle = PHANDLE_CPU | topology.decode(socket_id, core_id, thread_id) as u32;
@@ -234,7 +234,7 @@ where
                 .collect(),
         };
 
-        let cpus_nodes = (0..(self.config.cpu.count))
+        let cpus_nodes = (0..(self.spec.cpu.count))
             .map(|index| {
                 let mpidr = self.encode_cpu_identity(index);
                 (
@@ -318,7 +318,7 @@ where
         let ppi = 1;
         let level_trigger = 4;
         let cpu_mask = match self.arch.gic {
-            Gic::V2(_) => (1 << self.config.cpu.count) - 1,
+            Gic::V2(_) => (1 << self.spec.cpu.count) - 1,
             Gic::V3 { .. } => 0,
         };
         for pin in irq_pins {
@@ -405,7 +405,7 @@ where
                             GIC_DIST_START,
                             64 << 10,
                             GIC_V3_REDIST_START,
-                            self.config.cpu.count as u64 * (128 << 10),
+                            self.spec.cpu.count as u64 * (128 << 10),
                         ]),
                     ),
                     ("phandle", PropVal::U32(PHANDLE_GIC)),
@@ -435,7 +435,7 @@ where
         let Some(max_bus) = self.pci_bus.segment.max_bus() else {
             return;
         };
-        let pcie_mmio_64_start = self.config.pcie_mmio_64_start();
+        let pcie_mmio_64_start = self.spec.pcie_mmio_64_start();
         let prefetchable = 1 << 30;
         let io = 0b01 << 24;
         let mem_32 = 0b10 << 24;

--- a/alioth/src/board/board_test.rs
+++ b/alioth/src/board/board_test.rs
@@ -14,10 +14,10 @@
 
 use rstest::rstest;
 
-use crate::board::{CpuConfig, CpuTopology};
+use crate::board::{CpuSpec, CpuTopology};
 
 #[rstest]
-#[case(CpuConfig {
+#[case(CpuSpec {
     count: 2,
     topology: CpuTopology {
         smt: false,
@@ -25,7 +25,7 @@ use crate::board::{CpuConfig, CpuTopology};
         sockets: 1,
     },
 }, true)]
-#[case(CpuConfig {
+#[case(CpuSpec {
     count: 2,
     topology: CpuTopology {
         smt: true,
@@ -33,8 +33,8 @@ use crate::board::{CpuConfig, CpuTopology};
         sockets: 1,
     },
 }, false)]
-fn test_cpu_topology_validate(#[case] config: CpuConfig, #[case] expected: bool) {
-    assert_eq!(config.validate(), expected);
+fn test_cpu_topology_validate(#[case] spec: CpuSpec, #[case] expected: bool) {
+    assert_eq!(spec.validate(), expected);
 }
 
 #[rstest]

--- a/alioth/src/cpu/cpu_amd64/cpu_amd64.rs
+++ b/alioth/src/cpu/cpu_amd64/cpu_amd64.rs
@@ -19,8 +19,8 @@ use std::path::Path;
 
 use crate::arch::msr::{MiscEnable, Msr};
 use crate::cpu::{Result, VcpuHandle, VcpuThread};
-use crate::hv::{Coco, Vcpu, Vm};
-use crate::loader::{InitState, Payload, firmware};
+use crate::hv::{CocoSpec, Vcpu, Vm};
+use crate::loader::{InitState, PayloadSpec, firmware};
 use crate::mem::mapped::ArcMemPages;
 
 impl<V: Vm> VcpuThread<V> {
@@ -43,7 +43,7 @@ impl<V: Vm> VcpuThread<V> {
     }
 
     pub(crate) fn init_boot_vcpu(&mut self, init: &InitState) -> Result<()> {
-        if matches!(self.ctx.board.config.coco, Some(Coco::IntelTdx { .. })) {
+        if matches!(self.ctx.board.spec.coco, Some(CocoSpec::IntelTdx { .. })) {
             return Ok(());
         }
         self.vcpu
@@ -53,7 +53,7 @@ impl<V: Vm> VcpuThread<V> {
     }
 
     pub(crate) fn init_ap(&mut self, vcpus: &[VcpuHandle]) -> Result<()> {
-        let Some(coco) = &self.ctx.board.config.coco else {
+        let Some(coco) = &self.ctx.board.spec.coco else {
             return Ok(());
         };
         self.sync_vcpus(vcpus)?;
@@ -61,30 +61,30 @@ impl<V: Vm> VcpuThread<V> {
             return Ok(());
         }
         match coco {
-            Coco::AmdSev { policy } => {
+            CocoSpec::AmdSev { policy } => {
                 if policy.es() {
                     self.sev_init_ap()?;
                 }
             }
-            Coco::AmdSnp { .. } => self.sev_init_ap()?,
-            Coco::IntelTdx { .. } => self.tdx_init_ap()?,
+            CocoSpec::AmdSnp { .. } => self.sev_init_ap()?,
+            CocoSpec::IntelTdx { .. } => self.tdx_init_ap()?,
         }
         Ok(())
     }
 
     pub(crate) fn setup_coco(&self, fw: &mut ArcMemPages) -> Result<()> {
-        let Some(coco) = &self.ctx.board.config.coco else {
+        let Some(coco) = &self.ctx.board.spec.coco else {
             return Ok(());
         };
         match coco {
-            Coco::AmdSev { policy } => self.setup_sev(fw, *policy),
-            Coco::AmdSnp { .. } => self.setup_snp(fw),
-            Coco::IntelTdx { .. } => self.setup_tdx(fw),
+            CocoSpec::AmdSev { policy } => self.setup_sev(fw, *policy),
+            CocoSpec::AmdSnp { .. } => self.setup_snp(fw),
+            CocoSpec::IntelTdx { .. } => self.setup_tdx(fw),
         }
     }
 
     pub(crate) fn coco_finalize(&self, vcpus: &[VcpuHandle]) -> Result<()> {
-        let Some(coco) = &self.ctx.board.config.coco else {
+        let Some(coco) = &self.ctx.board.spec.coco else {
             return Ok(());
         };
         self.sync_vcpus(vcpus)?;
@@ -92,13 +92,13 @@ impl<V: Vm> VcpuThread<V> {
             return Ok(());
         };
         match coco {
-            Coco::AmdSev { policy } => self.sev_finalize(*policy),
-            Coco::AmdSnp { .. } => self.snp_finalize(),
-            Coco::IntelTdx { .. } => self.tdx_finalize(),
+            CocoSpec::AmdSev { policy } => self.sev_finalize(*policy),
+            CocoSpec::AmdSnp { .. } => self.snp_finalize(),
+            CocoSpec::IntelTdx { .. } => self.tdx_finalize(),
         }
     }
 
-    pub(crate) fn setup_firmware(&self, fw: &Path, payload: &Payload) -> Result<InitState> {
+    pub(crate) fn setup_firmware(&self, fw: &Path, payload: &PayloadSpec) -> Result<InitState> {
         let (init_state, mut rom) = firmware::load(&self.ctx.board.memory, fw)?;
         self.setup_coco(&mut rom)?;
         self.ctx.board.setup_fw_cfg(payload)?;

--- a/alioth/src/cpu/cpu_arm64.rs
+++ b/alioth/src/cpu/cpu_arm64.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 use crate::cpu::{Result, VcpuHandle, VcpuThread};
 use crate::hv::{Vcpu, Vm};
-use crate::loader::{InitState, Payload};
+use crate::loader::{InitState, PayloadSpec};
 
 impl<V: Vm> VcpuThread<V> {
     pub(crate) fn init_vcpu(&mut self) -> Result<()> {
@@ -37,7 +37,7 @@ impl<V: Vm> VcpuThread<V> {
         Ok(())
     }
 
-    pub(crate) fn setup_firmware(&self, _: &Path, _: &Payload) -> Result<InitState> {
+    pub(crate) fn setup_firmware(&self, _: &Path, _: &PayloadSpec) -> Result<InitState> {
         unimplemented!()
     }
 

--- a/alioth/src/device/fw_cfg/fw_cfg.rs
+++ b/alioth/src/device/fw_cfg/fw_cfg.rs
@@ -541,7 +541,7 @@ impl Pause for Mutex<FwCfg> {
 impl MmioDev for Mutex<FwCfg> {}
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Help)]
-pub enum FwCfgContentParam {
+pub enum FwCfgContentSpec {
     /// Path to a file with binary contents.
     #[serde(alias = "file")]
     File(Box<Path>),
@@ -551,15 +551,15 @@ pub enum FwCfgContentParam {
 }
 
 #[derive(Debug, PartialEq, Eq, Help)]
-pub struct FwCfgItemParam {
+pub struct FwCfgItemSpec {
     /// Selector key of an item.
     pub name: String,
     /// Item content.
     #[serde_aco(flatten)]
-    pub content: FwCfgContentParam,
+    pub content: FwCfgContentSpec,
 }
 
-impl<'de> Deserialize<'de> for FwCfgItemParam {
+impl<'de> Deserialize<'de> for FwCfgItemSpec {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -572,13 +572,13 @@ impl<'de> Deserialize<'de> for FwCfgItemParam {
             String,
         }
 
-        struct ParamVisitor;
+        struct SpecVisitor;
 
-        impl<'de> Visitor<'de> for ParamVisitor {
-            type Value = FwCfgItemParam;
+        impl<'de> Visitor<'de> for SpecVisitor {
+            type Value = FwCfgItemSpec;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct FwCfgItemParam")
+                formatter.write_str("struct FwCfgItemSpec")
             }
 
             fn visit_map<V>(self, mut map: V) -> std::result::Result<Self::Value, V::Error>
@@ -599,38 +599,38 @@ impl<'de> Deserialize<'de> for FwCfgItemParam {
                             if content.is_some() {
                                 return Err(de::Error::duplicate_field("string,file"));
                             }
-                            content = Some(FwCfgContentParam::String(map.next_value()?));
+                            content = Some(FwCfgContentSpec::String(map.next_value()?));
                         }
                         Field::File => {
                             if content.is_some() {
                                 return Err(de::Error::duplicate_field("string,file"));
                             }
-                            content = Some(FwCfgContentParam::File(map.next_value()?));
+                            content = Some(FwCfgContentSpec::File(map.next_value()?));
                         }
                     }
                 }
                 let name = name.ok_or_else(|| de::Error::missing_field("name"))?;
                 let content = content.ok_or_else(|| de::Error::missing_field("file,string"))?;
-                Ok(FwCfgItemParam { name, content })
+                Ok(FwCfgItemSpec { name, content })
             }
         }
 
         const FIELDS: &[&str] = &["name", "file", "string"];
-        deserializer.deserialize_struct("FwCfgItemParam", FIELDS, ParamVisitor)
+        deserializer.deserialize_struct("FwCfgItemSpec", FIELDS, SpecVisitor)
     }
 }
 
-impl FwCfgItemParam {
+impl FwCfgItemSpec {
     pub fn build(self) -> Result<FwCfgItem> {
         match self.content {
-            FwCfgContentParam::File(file) => {
+            FwCfgContentSpec::File(file) => {
                 let f = File::open(file)?;
                 Ok(FwCfgItem {
                     name: self.name,
                     content: FwCfgContent::File(0, f),
                 })
             }
-            FwCfgContentParam::String(string) => Ok(FwCfgItem {
+            FwCfgContentSpec::String(string) => Ok(FwCfgItem {
                 name: self.name,
                 content: FwCfgContent::Bytes(string.into()),
             }),

--- a/alioth/src/hv/hv.rs
+++ b/alioth/src/hv/hv.rs
@@ -48,7 +48,7 @@ use crate::errors::{DebugTrace, trace_error};
 #[cfg(target_os = "macos")]
 pub use self::hvf::Hvf;
 #[cfg(target_os = "linux")]
-pub use self::kvm::{Kvm, KvmConfig, KvmError};
+pub use self::kvm::{Kvm, KvmError, KvmSpec};
 
 #[trace_error]
 #[derive(Snafu, DebugTrace)]
@@ -139,11 +139,11 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Deserialize, Clone, Help)]
 #[cfg_attr(target_os = "macos", derive(Default))]
-pub enum HvConfig {
+pub enum HvSpec {
     /// KVM backed by the Linux kernel.
     #[cfg(target_os = "linux")]
     #[serde(alias = "kvm")]
-    Kvm(KvmConfig),
+    Kvm(KvmSpec),
     /// macOS Hypervisor Framework.
     #[cfg(target_os = "macos")]
     #[default]
@@ -152,9 +152,9 @@ pub enum HvConfig {
 }
 
 #[cfg(target_os = "linux")]
-impl Default for HvConfig {
+impl Default for HvSpec {
     fn default() -> Self {
-        HvConfig::Kvm(KvmConfig::default())
+        HvSpec::Kvm(KvmSpec::default())
     }
 }
 
@@ -309,7 +309,7 @@ pub trait Its: Debug + Send + Sync + 'static {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Help)]
-pub enum Coco {
+pub enum CocoSpec {
     /// Enable AMD SEV or SEV-ES.
     #[cfg(target_arch = "x86_64")]
     #[serde(alias = "sev")]
@@ -337,8 +337,8 @@ pub enum Coco {
 }
 
 #[derive(Debug)]
-pub struct VmConfig {
-    pub coco: Option<Coco>,
+pub struct VmSpec {
+    pub coco: Option<CocoSpec>,
 }
 
 pub trait Vm {
@@ -416,10 +416,13 @@ pub trait Vm {
 pub trait Hypervisor {
     type Vm: Vm + Sync + Send + 'static;
 
-    fn create_vm(&self, config: &VmConfig) -> Result<Self::Vm, Error>;
+    fn create_vm(&self, spec: &VmSpec) -> Result<Self::Vm, Error>;
 
     #[cfg(target_arch = "x86_64")]
-    fn get_supported_cpuids(&self, coco: Option<&Coco>) -> Result<HashMap<CpuidIn, CpuidResult>>;
+    fn get_supported_cpuids(
+        &self,
+        coco: Option<&CocoSpec>,
+    ) -> Result<HashMap<CpuidIn, CpuidResult>>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/alioth/src/hv/hvf/hvf.rs
+++ b/alioth/src/hv/hvf/hvf.rs
@@ -20,7 +20,7 @@ use std::fmt::{Display, Formatter};
 use std::io::ErrorKind;
 use std::os::raw::c_void;
 
-use crate::hv::{Hypervisor, Result, VmConfig};
+use crate::hv::{Hypervisor, Result, VmSpec};
 use crate::sys::os::os_release;
 
 use self::vm::HvfVm;
@@ -81,7 +81,7 @@ pub struct Hvf {}
 impl Hypervisor for Hvf {
     type Vm = HvfVm;
 
-    fn create_vm(&self, _config: &VmConfig) -> Result<Self::Vm> {
+    fn create_vm(&self, _spec: &VmSpec) -> Result<Self::Vm> {
         HvfVm::new()
     }
 }

--- a/alioth/src/hv/hvf/vcpu/vcpu_test.rs
+++ b/alioth/src/hv/hvf/vcpu/vcpu_test.rs
@@ -19,14 +19,14 @@ use libc::{MAP_ANONYMOUS, MAP_FAILED, MAP_PRIVATE, PROT_READ, PROT_WRITE, mmap};
 
 use crate::arch::reg::Reg;
 use crate::ffi;
-use crate::hv::{Hvf, Hypervisor, MemMapOption, Vcpu, Vm, VmConfig, VmEntry, VmExit, VmMemory};
+use crate::hv::{Hvf, Hypervisor, MemMapOption, Vcpu, Vm, VmEntry, VmExit, VmMemory, VmSpec};
 
 #[test]
 #[cfg_attr(not(feature = "test-hv"), ignore)]
 fn test_vcpu_regs() {
     let hvf = Hvf {};
-    let config = VmConfig { coco: None };
-    let vm = hvf.create_vm(&config).unwrap();
+    let spec = VmSpec { coco: None };
+    let vm = hvf.create_vm(&spec).unwrap();
     let mut vcpu = vm.create_vcpu(0, 0).unwrap();
     let regs = [
         (Reg::X0, 0),
@@ -74,8 +74,8 @@ fn test_vcpu_regs() {
 #[cfg_attr(not(feature = "test-hv"), ignore)]
 fn test_vcpu_run() {
     let hvf = Hvf {};
-    let config = VmConfig { coco: None };
-    let mut vm = hvf.create_vm(&config).unwrap();
+    let spec = VmSpec { coco: None };
+    let mut vm = hvf.create_vm(&spec).unwrap();
     let memory = vm.create_vm_memory().unwrap();
 
     let prot = PROT_WRITE | PROT_READ;

--- a/alioth/src/hv/kvm/kvm.rs
+++ b/alioth/src/hv/kvm/kvm.rs
@@ -44,8 +44,8 @@ use crate::arch::cpuid::CpuidIn;
 use crate::errors::{DebugTrace, trace_error};
 use crate::ffi;
 #[cfg(target_arch = "x86_64")]
-use crate::hv::Coco;
-use crate::hv::{Hypervisor, MemMapOption, Result, VmConfig, error};
+use crate::hv::CocoSpec;
+use crate::hv::{Hypervisor, MemMapOption, Result, VmSpec, error};
 #[cfg(target_arch = "aarch64")]
 use crate::sys::kvm::KvmDevType;
 use crate::sys::kvm::{KVM_API_VERSION, KvmCap, kvm_check_extension, kvm_get_api_version};
@@ -96,11 +96,11 @@ pub enum KvmError {
 pub struct Kvm {
     fd: OwnedFd,
     #[cfg(target_arch = "x86_64")]
-    config: KvmConfig,
+    spec: KvmSpec,
 }
 
 #[derive(Debug, Deserialize, Default, Clone, Help)]
-pub struct KvmConfig {
+pub struct KvmSpec {
     /// Path to the KVM device. [default: /dev/kvm]
     pub dev_kvm: Option<Box<Path>>,
     /// Path to the AMD SEV device. [default: /dev/sev]
@@ -111,8 +111,8 @@ pub struct KvmConfig {
 extern "C" fn sigrtmin_handler(_: libc::c_int, _: *mut libc::siginfo_t, _: *mut libc::c_void) {}
 
 impl Kvm {
-    pub fn new(config: KvmConfig) -> Result<Self> {
-        let path = match &config.dev_kvm {
+    pub fn new(spec: KvmSpec) -> Result<Self> {
+        let path = match &spec.dev_kvm {
             Some(dev_kvm) => dev_kvm,
             None => Path::new("/dev/kvm"),
         };
@@ -134,7 +134,7 @@ impl Kvm {
         Ok(Kvm {
             fd: kvm_fd,
             #[cfg(target_arch = "x86_64")]
-            config,
+            spec,
         })
     }
 
@@ -146,12 +146,15 @@ impl Kvm {
 impl Hypervisor for Kvm {
     type Vm = KvmVm;
 
-    fn create_vm(&self, config: &VmConfig) -> Result<Self::Vm> {
-        KvmVm::new(self, config)
+    fn create_vm(&self, spec: &VmSpec) -> Result<Self::Vm> {
+        KvmVm::new(self, spec)
     }
 
     #[cfg(target_arch = "x86_64")]
-    fn get_supported_cpuids(&self, coco: Option<&Coco>) -> Result<HashMap<CpuidIn, CpuidResult>> {
+    fn get_supported_cpuids(
+        &self,
+        coco: Option<&CocoSpec>,
+    ) -> Result<HashMap<CpuidIn, CpuidResult>> {
         Kvm::get_supported_cpuids(self, coco)
     }
 }

--- a/alioth/src/hv/kvm/kvm_amd64/kvm_amd64.rs
+++ b/alioth/src/hv/kvm/kvm_amd64/kvm_amd64.rs
@@ -22,7 +22,7 @@ use snafu::ResultExt;
 
 use crate::arch::cpuid::CpuidIn;
 #[cfg(target_arch = "x86_64")]
-use crate::hv::Coco;
+use crate::hv::CocoSpec;
 use crate::hv::{Kvm, Result, error};
 use crate::sys::kvm::{
     KVM_CPUID_FEATURES, KVM_MAX_CPUID_ENTRIES, KvmCap, KvmCpuid2, KvmCpuid2Flag, KvmCpuidEntry2,
@@ -52,7 +52,7 @@ impl From<KvmCpuidEntry2> for (CpuidIn, CpuidResult) {
 impl Kvm {
     pub fn get_supported_cpuids(
         &self,
-        coco: Option<&Coco>,
+        coco: Option<&CocoSpec>,
     ) -> Result<HashMap<CpuidIn, CpuidResult>> {
         let mut kvm_cpuid2 = KvmCpuid2 {
             nent: KVM_MAX_CPUID_ENTRIES as u32,
@@ -81,7 +81,7 @@ impl Kvm {
                 // Enable KVM_FEATURE_MSI_EXT_DEST_ID if KVM_CAP_X2APIC_API is supported
                 entry.eax |= KvmCpuidFeature::MSI_EXT_DEST_ID.bits();
             }
-            if matches!(coco, Some(Coco::IntelTdx { .. })) {
+            if matches!(coco, Some(CocoSpec::IntelTdx { .. })) {
                 entry.eax &= tdx::SUPPORTED_KVM_FEATURES;
             }
         }

--- a/alioth/src/hv/kvm/kvm_amd64/kvm_amd64_test.rs
+++ b/alioth/src/hv/kvm/kvm_amd64/kvm_amd64_test.rs
@@ -17,13 +17,13 @@ use std::arch::x86_64::CpuidResult;
 use rstest::rstest;
 
 use crate::arch::cpuid::CpuidIn;
-use crate::hv::kvm::{Kvm, KvmConfig};
+use crate::hv::kvm::{Kvm, KvmSpec};
 use crate::sys::kvm::{KVM_CPUID_SIGNATURE, KvmCpuid2Flag, KvmCpuidEntry2};
 
 #[test]
 #[cfg_attr(not(feature = "test-hv"), ignore)]
 fn test_get_supported_cpuid() {
-    let kvm = Kvm::new(KvmConfig::default()).unwrap();
+    let kvm = Kvm::new(KvmSpec::default()).unwrap();
     let mut kvm_cpuid_exist = false;
     let supported_cpuids = kvm.get_supported_cpuids(None).unwrap();
     for (in_, out) in &supported_cpuids {

--- a/alioth/src/hv/kvm/vcpu/vcpu_amd64/vcpu_amd64_test.rs
+++ b/alioth/src/hv/kvm/vcpu/vcpu_amd64/vcpu_amd64_test.rs
@@ -30,12 +30,12 @@ use crate::hv::{
 #[test]
 #[cfg_attr(not(feature = "test-hv"), ignore)]
 fn test_vcpu_regs() {
-    use crate::hv::VmConfig;
-    use crate::hv::kvm::KvmConfig;
+    use crate::hv::VmSpec;
+    use crate::hv::kvm::KvmSpec;
 
-    let kvm = Kvm::new(KvmConfig::default()).unwrap();
-    let vm_config = VmConfig { coco: None };
-    let vm = kvm.create_vm(&vm_config).unwrap();
+    let kvm = Kvm::new(KvmSpec::default()).unwrap();
+    let spec = VmSpec { coco: None };
+    let vm = kvm.create_vm(&spec).unwrap();
     let mut vcpu = vm.create_vcpu(0, 0).unwrap();
     let regs = [
         (Reg::Rax, 0xa93f90f6ce9c8040),
@@ -176,12 +176,12 @@ fn test_vcpu_regs() {
 #[test]
 #[cfg_attr(not(feature = "test-hv"), ignore)]
 fn test_kvm_run() {
-    use crate::hv::VmConfig;
-    use crate::hv::kvm::KvmConfig;
+    use crate::hv::VmSpec;
+    use crate::hv::kvm::KvmSpec;
 
-    let kvm = Kvm::new(KvmConfig::default()).unwrap();
-    let vm_config = VmConfig { coco: None };
-    let mut vm = kvm.create_vm(&vm_config).unwrap();
+    let kvm = Kvm::new(KvmSpec::default()).unwrap();
+    let spec = VmSpec { coco: None };
+    let mut vm = kvm.create_vm(&spec).unwrap();
     let memory = vm.create_vm_memory().unwrap();
 
     let prot = PROT_WRITE | PROT_EXEC | PROT_READ;

--- a/alioth/src/hv/kvm/vm/vm.rs
+++ b/alioth/src/hv/kvm/vm/vm.rs
@@ -46,7 +46,7 @@ use crate::hv::kvm::vcpu::KvmVcpu;
 use crate::hv::kvm::{KvmError, check_extension, kvm_error};
 use crate::hv::{
     Error, IoeventFd, IoeventFdRegistry, IrqFd, IrqSender, Kvm, MemMapOption, MsiSender, Result,
-    Vm, VmConfig, VmMemory, error,
+    Vm, VmMemory, VmSpec, error,
 };
 #[cfg(target_arch = "x86_64")]
 use crate::sys::kvm::KVM_IRQCHIP_IOAPIC;
@@ -600,14 +600,14 @@ pub struct KvmVm {
 }
 
 impl KvmVm {
-    pub fn new(kvm: &Kvm, config: &VmConfig) -> Result<Self> {
+    pub fn new(kvm: &Kvm, spec: &VmSpec) -> Result<Self> {
         let vcpu_mmap_size =
             unsafe { kvm_get_vcpu_mmap_size(&kvm.fd) }.context(error::CreateVm)? as usize;
-        let kvm_vm_type = Self::determine_vm_type(config);
+        let kvm_vm_type = Self::determine_vm_type(spec);
         let vm_fd = unsafe { kvm_create_vm(&kvm.fd, kvm_vm_type) }.context(error::CreateVm)?;
         let fd = unsafe { OwnedFd::from_raw_fd(vm_fd) };
-        let arch = VmArch::new(kvm, config)?;
-        let memfd = Self::create_guest_memfd(config, &fd)?;
+        let arch = VmArch::new(kvm, spec)?;
+        let memfd = Self::create_guest_memfd(spec, &fd)?;
         let kvm_vm = KvmVm {
             vm: Arc::new(VmInner {
                 fd,
@@ -621,7 +621,7 @@ impl KvmVm {
             }),
             memory_created: false,
         };
-        kvm_vm.init(config)?;
+        kvm_vm.init(spec)?;
         Ok(kvm_vm)
     }
 }

--- a/alioth/src/hv/kvm/vm/vm_amd64/vm_amd64.rs
+++ b/alioth/src/hv/kvm/vm/vm_amd64/vm_amd64.rs
@@ -24,7 +24,7 @@ use crate::arch::intr::{MsiAddrHi, MsiAddrLo};
 use crate::arch::ioapic::NUM_PINS;
 use crate::hv::kvm::x86_64::sev::SevFd;
 use crate::hv::kvm::{KvmVm, kvm_error};
-use crate::hv::{Coco, Kvm, Result, VmConfig, error};
+use crate::hv::{CocoSpec, Kvm, Result, VmSpec, error};
 use crate::sys::kvm::{
     KvmCap, KvmCreateGuestMemfd, KvmVmType, KvmX2apicApiFlag, kvm_create_guest_memfd,
     kvm_set_identity_map_addr, kvm_set_tss_addr,
@@ -48,39 +48,39 @@ pub struct VmArch {
 }
 
 impl VmArch {
-    pub fn new(kvm: &Kvm, config: &VmConfig) -> Result<Self> {
-        let Some(coco) = &config.coco else {
+    pub fn new(kvm: &Kvm, spec: &VmSpec) -> Result<Self> {
+        let Some(coco) = &spec.coco else {
             return Ok(VmArch::default());
         };
         match coco {
-            Coco::AmdSev { .. } | Coco::AmdSnp { .. } => {
+            CocoSpec::AmdSev { .. } | CocoSpec::AmdSnp { .. } => {
                 let default_dev = Path::new("/dev/sev");
-                let dev_sev = kvm.config.dev_sev.as_deref().unwrap_or(default_dev);
+                let dev_sev = kvm.spec.dev_sev.as_deref().unwrap_or(default_dev);
                 let fd = SevFd::new(dev_sev)?;
                 Ok(VmArch { sev_fd: Some(fd) })
             }
-            Coco::IntelTdx { .. } => Ok(VmArch::default()),
+            CocoSpec::IntelTdx { .. } => Ok(VmArch::default()),
         }
     }
 }
 
 impl KvmVm {
-    pub fn determine_vm_type(config: &VmConfig) -> KvmVmType {
-        let Some(coco) = &config.coco else {
+    pub fn determine_vm_type(spec: &VmSpec) -> KvmVmType {
+        let Some(coco) = &spec.coco else {
             return KvmVmType::DEFAULT;
         };
         match coco {
-            Coco::AmdSev { .. } => KvmVmType::DEFAULT,
-            Coco::AmdSnp { .. } => KvmVmType::SNP,
-            Coco::IntelTdx { .. } => KvmVmType::TDX,
+            CocoSpec::AmdSev { .. } => KvmVmType::DEFAULT,
+            CocoSpec::AmdSnp { .. } => KvmVmType::SNP,
+            CocoSpec::IntelTdx { .. } => KvmVmType::TDX,
         }
     }
 
-    pub fn create_guest_memfd(config: &VmConfig, fd: &OwnedFd) -> Result<Option<OwnedFd>> {
-        let Some(coco) = &config.coco else {
+    pub fn create_guest_memfd(spec: &VmSpec, fd: &OwnedFd) -> Result<Option<OwnedFd>> {
+        let Some(coco) = &spec.coco else {
             return Ok(None);
         };
-        if !matches!(coco, Coco::AmdSnp { .. } | Coco::IntelTdx { .. }) {
+        if !matches!(coco, CocoSpec::AmdSnp { .. } | CocoSpec::IntelTdx { .. }) {
             return Ok(None);
         }
         let mut gmem = KvmCreateGuestMemfd {
@@ -91,7 +91,7 @@ impl KvmVm {
         Ok(Some(unsafe { OwnedFd::from_raw_fd(fd) }))
     }
 
-    pub fn init(&self, config: &VmConfig) -> Result<()> {
+    pub fn init(&self, spec: &VmSpec) -> Result<()> {
         let x2apic_caps =
             KvmX2apicApiFlag::USE_32BIT_IDS | KvmX2apicApiFlag::DISABLE_BROADCAST_QUIRK;
         if let Err(e) = self.vm.enable_cap(KvmCap::X2APIC_API, x2apic_caps.bits()) {
@@ -103,11 +103,11 @@ impl KvmVm {
         unsafe { kvm_set_identity_map_addr(&self.vm.fd, &0xf000_3000) }
             .context(error::SetVmParam)?;
 
-        if let Some(coco) = &config.coco {
+        if let Some(coco) = &spec.coco {
             match coco {
-                Coco::AmdSev { policy } => self.sev_init(*policy),
-                Coco::AmdSnp { .. } => self.snp_init(),
-                Coco::IntelTdx { .. } => self.tdx_init(),
+                CocoSpec::AmdSev { policy } => self.sev_init(*policy),
+                CocoSpec::AmdSnp { .. } => self.snp_init(),
+                CocoSpec::IntelTdx { .. } => self.tdx_init(),
             }?;
         }
 

--- a/alioth/src/hv/kvm/vm/vm_amd64/vm_amd64_test.rs
+++ b/alioth/src/hv/kvm/vm/vm_amd64/vm_amd64_test.rs
@@ -18,7 +18,7 @@ use crate::arch::sev::{SevPolicy, SnpPolicy};
 use crate::arch::tdx::TdAttr;
 use crate::hv::kvm::vm::KvmVm;
 use crate::hv::kvm::vm::x86_64::translate_msi_addr;
-use crate::hv::{Coco, VmConfig};
+use crate::hv::{CocoSpec, VmSpec};
 use crate::sys::kvm::KvmVmType;
 
 #[rstest]
@@ -33,31 +33,31 @@ fn test_translate_msi_addr(#[case] addr: u64, #[case] expected: u64) {
 }
 
 #[rstest]
-#[case(VmConfig { coco: None }, KvmVmType::DEFAULT)]
+#[case(VmSpec { coco: None }, KvmVmType::DEFAULT)]
 #[case(
-    VmConfig {
-        coco: Some(Coco::AmdSev {
+    VmSpec {
+        coco: Some(CocoSpec::AmdSev {
             policy: SevPolicy(0x5)
         })
     },
     KvmVmType::DEFAULT
 )]
 #[case(
-    VmConfig {
-        coco: Some(Coco::AmdSnp {
+    VmSpec {
+        coco: Some(CocoSpec::AmdSnp {
             policy: SnpPolicy(0x30000)
         })
     },
     KvmVmType::SNP
 )]
 #[case(
-    VmConfig {
-        coco: Some(Coco::IntelTdx {
+    VmSpec {
+        coco: Some(CocoSpec::IntelTdx {
             attr: TdAttr::empty()
         })
     },
     KvmVmType::TDX
 )]
-fn test_determine_vm_type(#[case] config: VmConfig, #[case] vm_type: KvmVmType) {
-    assert_eq!(KvmVm::determine_vm_type(&config), vm_type)
+fn test_determine_vm_type(#[case] spec: VmSpec, #[case] vm_type: KvmVmType) {
+    assert_eq!(KvmVm::determine_vm_type(&spec), vm_type)
 }

--- a/alioth/src/hv/kvm/vm/vm_arm64.rs
+++ b/alioth/src/hv/kvm/vm/vm_arm64.rs
@@ -17,7 +17,7 @@ use std::os::fd::OwnedFd;
 use crate::hv::kvm::Result;
 use crate::hv::kvm::device::KvmDevice;
 use crate::hv::kvm::vm::KvmVm;
-use crate::hv::{GicV2, GicV2m, GicV3, Its, Kvm, VmConfig};
+use crate::hv::{GicV2, GicV2m, GicV3, Its, Kvm, VmSpec};
 use crate::sys::kvm::{
     KvmDevArmVgicCtrl, KvmDevArmVgicGrp, KvmDevType, KvmVgicAddrType, KvmVgicV3RedistRegion,
     KvmVmType,
@@ -179,21 +179,21 @@ impl Its for KvmIts {
 pub struct VmArch;
 
 impl VmArch {
-    pub fn new(_kvm: &Kvm, _config: &VmConfig) -> Result<Self> {
+    pub fn new(_kvm: &Kvm, _spec: &VmSpec) -> Result<Self> {
         Ok(VmArch)
     }
 }
 
 impl KvmVm {
-    pub fn determine_vm_type(_config: &VmConfig) -> KvmVmType {
+    pub fn determine_vm_type(_spec: &VmSpec) -> KvmVmType {
         KvmVmType(0)
     }
 
-    pub fn create_guest_memfd(_config: &VmConfig, _fd: &OwnedFd) -> Result<Option<OwnedFd>> {
+    pub fn create_guest_memfd(_spec: &VmSpec, _fd: &OwnedFd) -> Result<Option<OwnedFd>> {
         Ok(None)
     }
 
-    pub fn init(&self, _config: &VmConfig) -> Result<()> {
+    pub fn init(&self, _spec: &VmSpec) -> Result<()> {
         Ok(())
     }
 }

--- a/alioth/src/hv/kvm/vm/vm_test.rs
+++ b/alioth/src/hv/kvm/vm/vm_test.rs
@@ -19,15 +19,15 @@ use libc::{MAP_ANONYMOUS, MAP_FAILED, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WR
 
 use super::*;
 use crate::ffi;
-use crate::hv::kvm::KvmConfig;
-use crate::hv::{Hypervisor, Kvm, MemMapOption, VmConfig};
+use crate::hv::kvm::KvmSpec;
+use crate::hv::{Hypervisor, Kvm, MemMapOption, VmSpec};
 
 #[test]
 #[cfg_attr(not(feature = "test-hv"), ignore)]
 fn test_mem_map() {
-    let kvm = Kvm::new(KvmConfig::default()).unwrap();
-    let vm_config = VmConfig { coco: None };
-    let mut vm = kvm.create_vm(&vm_config).unwrap();
+    let kvm = Kvm::new(KvmSpec::default()).unwrap();
+    let spec = VmSpec { coco: None };
+    let mut vm = kvm.create_vm(&spec).unwrap();
     let vm_memory = vm.create_vm_memory().unwrap();
 
     let prot = PROT_WRITE | PROT_READ | PROT_EXEC;

--- a/alioth/src/loader/loader.rs
+++ b/alioth/src/loader/loader.rs
@@ -36,7 +36,7 @@ use crate::errors::{DebugTrace, trace_error};
 use crate::mem::{MemRegionEntry, MemRegionType};
 
 #[derive(Debug, Default, PartialEq, Eq, Deserialize)]
-pub struct Payload {
+pub struct PayloadSpec {
     pub firmware: Option<Box<Path>>,
     pub executable: Option<Executable>,
     pub initramfs: Option<Box<Path>>,

--- a/alioth/src/mem/mem.rs
+++ b/alioth/src/mem/mem.rs
@@ -82,7 +82,7 @@ fn default_memory_size() -> u64 {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Deserialize, Help)]
-pub struct MemConfig {
+pub struct MemSpec {
     /// Total guest memory size in bytes. [default: 1G]
     #[serde(default = "default_memory_size")]
     pub size: u64,
@@ -111,7 +111,7 @@ pub enum MemBackend {
     Memfd,
 }
 
-impl MemConfig {
+impl MemSpec {
     pub fn has_shared_fd(&self) -> bool {
         match &self.backend {
             #[cfg(target_os = "linux")]

--- a/alioth/src/vfio/vfio.rs
+++ b/alioth/src/vfio/vfio.rs
@@ -52,7 +52,7 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Help)]
-pub struct CdevParam {
+pub struct VfioCdevSpec {
     /// Path to a VFIO cdev, e.g. /dev/vfio/devices/vfio0.
     pub path: Box<Path>,
     /// Name of the IO Address space to which this device should be attached.
@@ -60,7 +60,7 @@ pub struct CdevParam {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Help)]
-pub struct IoasParam {
+pub struct VfioIoasSpec {
     /// Name of the IO Address space.
     pub name: Box<str>,
     /// Path to the iommu device. [default: /dev/iommu]
@@ -68,7 +68,7 @@ pub struct IoasParam {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Help)]
-pub struct GroupParam {
+pub struct VfioGroupSpec {
     /// Path to a VFIO group file, e.g. /dev/vfio/12.
     pub path: Box<Path>,
     /// Device ID, e.g. 0000:06:0d.0.
@@ -79,7 +79,7 @@ pub struct GroupParam {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Help)]
-pub struct ContainerParam {
+pub struct VfioContainerSpec {
     /// Name of the Container.
     pub name: Box<str>,
     /// Path to the vfio device. [default: /dev/vfio/vfio]

--- a/alioth/src/virtio/dev/balloon.rs
+++ b/alioth/src/virtio/dev/balloon.rs
@@ -31,7 +31,7 @@ use crate::hv::IoeventFd;
 use crate::mem::emulated::{Action, Mmio};
 use crate::mem::mapped::{Ram, RamBus};
 use crate::sync::notifier::Notifier;
-use crate::virtio::dev::{DevParam, DeviceId, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, DeviceId, Virtio, WakeEvent};
 use crate::virtio::queue::{QueueReg, Status, VirtQueue};
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{FEATURE_BUILT_IN, IrqSender, Result};
@@ -126,7 +126,7 @@ pub struct Balloon {
 }
 
 impl Balloon {
-    pub fn new(param: BalloonParam, name: impl Into<Arc<str>>) -> Result<Self> {
+    pub fn new(spec: BalloonSpec, name: impl Into<Arc<str>>) -> Result<Self> {
         if unsafe { sysconf(_SC_PAGESIZE) } != 1 << 12 {
             let err = std::io::ErrorKind::Unsupported;
             Err(std::io::Error::from(err))?;
@@ -136,7 +136,7 @@ impl Balloon {
             ..Default::default()
         };
         let mut feature = BalloonFeature::all();
-        if !param.free_page_reporting {
+        if !spec.free_page_reporting {
             feature.remove(BalloonFeature::PAGE_REPORTING);
         };
         let name = name.into();
@@ -314,13 +314,13 @@ impl VirtioMio for Balloon {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Help)]
-pub struct BalloonParam {
+pub struct BalloonSpec {
     /// Enable free page reporting. [default: false]
     #[serde(default)]
     pub free_page_reporting: bool,
 }
 
-impl DevParam for BalloonParam {
+impl DevSpec for BalloonSpec {
     type Device = Balloon;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<Self::Device> {

--- a/alioth/src/virtio/dev/blk.rs
+++ b/alioth/src/virtio/dev/blk.rs
@@ -38,7 +38,7 @@ use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes};
 use crate::hv::IoeventFd;
 use crate::mem::mapped::RamBus;
 use crate::sync::notifier::Notifier;
-use crate::virtio::dev::{DevParam, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, Virtio, WakeEvent};
 use crate::virtio::queue::{DescChain, QueueReg, Status as QStatus, VirtQueue};
 use crate::virtio::worker::WorkerApi;
 #[cfg(target_os = "linux")]
@@ -135,7 +135,7 @@ pub struct BlockConfig {
 impl_mmio_for_zerocopy!(BlockConfig);
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Help)]
-pub struct BlkFileParam {
+pub struct BlkFileSpec {
     /// Path to a raw-formatted disk image.
     pub path: Box<Path>,
     /// Set the device as readonly. [default: false]
@@ -146,7 +146,7 @@ pub struct BlkFileParam {
     pub api: WorkerApi,
 }
 
-impl DevParam for BlkFileParam {
+impl DevSpec for BlkFileSpec {
     type Device = Block;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<Block> {
@@ -183,20 +183,20 @@ pub struct Block {
 }
 
 impl Block {
-    pub fn new(param: BlkFileParam, name: impl Into<Arc<str>>) -> Result<Self> {
+    pub fn new(spec: BlkFileSpec, name: impl Into<Arc<str>>) -> Result<Self> {
         let access_disk = error::AccessFile {
-            path: param.path.as_ref(),
+            path: spec.path.as_ref(),
         };
         let disk = OpenOptions::new()
             .read(true)
-            .write(!param.readonly)
-            .open(&param.path)
+            .write(!spec.readonly)
+            .open(&spec.path)
             .context(access_disk)?;
 
         let ctx_lock = error::LockFile {
-            path: param.path.as_ref(),
+            path: spec.path.as_ref(),
         };
-        if param.readonly {
+        if spec.readonly {
             disk.try_lock_shared().context(ctx_lock)
         } else {
             disk.try_lock().context(ctx_lock)
@@ -210,7 +210,7 @@ impl Block {
         };
         let config = Arc::new(config);
         let mut feature = BlockFeature::FLUSH;
-        if param.readonly {
+        if spec.readonly {
             feature |= BlockFeature::RO;
         }
         Ok(Block {
@@ -218,7 +218,7 @@ impl Block {
             disk,
             config,
             feature,
-            api: param.api,
+            api: spec.api,
         })
     }
 

--- a/alioth/src/virtio/dev/dev.rs
+++ b/alioth/src/virtio/dev/dev.rs
@@ -431,7 +431,7 @@ where
     }
 }
 
-pub trait DevParam {
+pub trait DevSpec {
     type Device;
     fn build(self, name: impl Into<Arc<str>>) -> Result<Self::Device>;
     fn needs_mem_shared_fd(&self) -> bool {

--- a/alioth/src/virtio/dev/entropy.rs
+++ b/alioth/src/virtio/dev/entropy.rs
@@ -31,7 +31,7 @@ use crate::hv::IoeventFd;
 use crate::mem::emulated::{Action, Mmio};
 use crate::mem::mapped::RamBus;
 use crate::sync::notifier::Notifier;
-use crate::virtio::dev::{DevParam, DeviceId, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, DeviceId, Virtio, WakeEvent};
 use crate::virtio::queue::{QueueReg, VirtQueue, copy_from_reader};
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{FEATURE_BUILT_IN, IrqSender, Result, error};
@@ -66,11 +66,11 @@ pub struct Entropy {
 }
 
 impl Entropy {
-    pub fn new(param: EntropyParam, name: impl Into<Arc<str>>) -> Result<Self> {
+    pub fn new(spec: EntropySpec, name: impl Into<Arc<str>>) -> Result<Self> {
         let name = name.into();
         let mut options = OpenOptions::new();
         options.custom_flags(O_NONBLOCK).read(true);
-        let path = param.source.as_deref().unwrap_or(Path::new("/dev/urandom"));
+        let path = spec.source.as_deref().unwrap_or(Path::new("/dev/urandom"));
         let file = options.open(path).context(error::AccessFile { path })?;
         Ok(Entropy {
             name,
@@ -166,12 +166,12 @@ impl VirtioMio for Entropy {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Help)]
-pub struct EntropyParam {
+pub struct EntropySpec {
     /// Source of entropy [default: /dev/urandom]
     pub source: Option<Box<Path>>,
 }
 
-impl DevParam for EntropyParam {
+impl DevSpec for EntropySpec {
     type Device = Entropy;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<Self::Device> {

--- a/alioth/src/virtio/dev/entropy_test.rs
+++ b/alioth/src/virtio/dev/entropy_test.rs
@@ -25,8 +25,8 @@ use tempfile::TempDir;
 
 use crate::ffi;
 use crate::mem::emulated::{Action, Mmio};
-use crate::virtio::dev::entropy::{EntropyConfig, EntropyParam};
-use crate::virtio::dev::{DevParam, StartParam, Virtio, WakeEvent};
+use crate::virtio::dev::entropy::{EntropyConfig, EntropySpec};
+use crate::virtio::dev::{DevSpec, StartParam, Virtio, WakeEvent};
 use crate::virtio::queue::QueueReg;
 use crate::virtio::queue::split::SplitQueue;
 use crate::virtio::queue::tests::GuestQueue;
@@ -65,7 +65,7 @@ fn entropy_test() {
     let pipe_path_c = CString::new(pipe_path.as_os_str().as_encoded_bytes()).unwrap();
     ffi!(unsafe { libc::mkfifo(pipe_path_c.as_ptr(), 0o600) }).unwrap();
 
-    let param = EntropyParam {
+    let param = EntropySpec {
         source: Some(pipe_path.clone().into()),
     };
     let dev = param.build("entropy").unwrap();

--- a/alioth/src/virtio/dev/fs/shared_dir.rs
+++ b/alioth/src/virtio/dev/fs/shared_dir.rs
@@ -21,11 +21,11 @@ use serde_aco::Help;
 
 use crate::fuse::passthrough::Passthrough;
 use crate::virtio::Result;
-use crate::virtio::dev::DevParam;
+use crate::virtio::dev::DevSpec;
 use crate::virtio::dev::fs::{Fs, FsConfig};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Help)]
-pub struct SharedDirParam {
+pub struct SharedDirSpec {
     /// Mount tag seen by the guest.
     pub tag: String,
     /// Path to the shared dir.
@@ -36,7 +36,7 @@ pub struct SharedDirParam {
     pub dax_window: usize,
 }
 
-impl DevParam for SharedDirParam {
+impl DevSpec for SharedDirSpec {
     type Device = Fs<Passthrough>;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<Fs<Passthrough>> {

--- a/alioth/src/virtio/dev/fs/vu.rs
+++ b/alioth/src/virtio/dev/fs/vu.rs
@@ -37,7 +37,7 @@ use crate::mem::mapped::{ArcMemPages, RamBus};
 use crate::mem::{LayoutChanged, MemRegion, MemRegionType};
 use crate::sync::notifier::Notifier;
 use crate::virtio::dev::fs::{DAX_SHMEM_ID, FsConfig, FsFeature};
-use crate::virtio::dev::{DevParam, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, Virtio, WakeEvent};
 use crate::virtio::queue::{QueueReg, VirtQueue};
 use crate::virtio::vu::bindings::{
     DeviceConfig, VhostUserMmap, VhostUserMmapFlag, VuBackMsg, VuFeature,
@@ -57,16 +57,16 @@ pub struct VuFs {
 }
 
 impl VuFs {
-    pub fn new(param: VuFsParam, name: impl Into<Arc<str>>) -> Result<Self> {
+    pub fn new(spec: VuFsSpec, name: impl Into<Arc<str>>) -> Result<Self> {
         let mut extra_features = VuFeature::empty();
-        if param.dax_window > 0 {
+        if spec.dax_window > 0 {
             extra_features |= VuFeature::BACKEND_REQ | VuFeature::BACKEND_SEND_FD | VuFeature::SHMEM
         };
-        if param.tag.is_none() {
+        if spec.tag.is_none() {
             extra_features |= VuFeature::CONFIG;
         }
-        let frontend = VuFrontend::new(name, &param.socket, DeviceId::FILE_SYSTEM, extra_features)?;
-        let config = if let Some(tag) = param.tag {
+        let frontend = VuFrontend::new(name, &spec.socket, DeviceId::FILE_SYSTEM, extra_features)?;
+        let config = if let Some(tag) = spec.tag {
             assert!(tag.len() <= 36);
             assert_ne!(tag.len(), 0);
             let mut config = FsConfig::new_zeroed();
@@ -88,8 +88,8 @@ impl VuFs {
             config
         };
 
-        let dax_region = if param.dax_window > 0 {
-            let size = align_up!(param.dax_window, 12);
+        let dax_region = if spec.dax_window > 0 {
+            let size = align_up!(spec.dax_window, 12);
             Some(ArcMemPages::from_anonymous(size, Some(PROT_NONE), None)?)
         } else {
             None
@@ -104,7 +104,7 @@ impl VuFs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Help)]
-pub struct VuFsParam {
+pub struct VuFsSpec {
     /// Path to the vhost-user UNIX domain socket.
     pub socket: Box<Path>,
     /// Mount tag seen by the guest.
@@ -115,7 +115,7 @@ pub struct VuFsParam {
     pub dax_window: usize,
 }
 
-impl DevParam for VuFsParam {
+impl DevSpec for VuFsSpec {
     type Device = VuFs;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<Self::Device> {

--- a/alioth/src/virtio/dev/net/tap.rs
+++ b/alioth/src/virtio/dev/net/tap.rs
@@ -43,7 +43,7 @@ use crate::sys::if_tun::{TunFeature, tun_set_iff, tun_set_offload, tun_set_vnet_
 use crate::virtio::dev::net::{
     CtrlAck, CtrlClass, CtrlHdr, CtrlMq, CtrlMqParisSet, NetConfig, NetFeature, VirtioNetHdr,
 };
-use crate::virtio::dev::{DevParam, DeviceId, Result, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, DeviceId, Result, Virtio, WakeEvent};
 use crate::virtio::queue::{
     DescChain, QueueReg, Status, VirtQueue, copy_from_reader, copy_to_writer,
 };
@@ -65,7 +65,7 @@ pub struct Net {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Help)]
-pub struct NetTapParam {
+pub struct TapNetSpec {
     /// MAC address of the virtual NIC, e.g. 06:3a:76:53:da:3d.
     pub mac: MacAddr,
     /// Maximum transmission unit.
@@ -88,7 +88,7 @@ pub struct NetTapParam {
     pub api: WorkerApi,
 }
 
-impl DevParam for NetTapParam {
+impl DevSpec for TapNetSpec {
     type Device = Net;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<Net> {
@@ -108,13 +108,10 @@ fn new_socket(dev_tap: Option<&Path>, blocking: bool) -> Result<File> {
 }
 
 impl Net {
-    pub fn new(param: NetTapParam, name: impl Into<Arc<str>>) -> Result<Self> {
-        let mut socket = new_socket(
-            param.tap.as_deref(),
-            matches!(param.api, WorkerApi::IoUring),
-        )?;
-        let max_queue_pairs = max(param.queue_pairs, 1);
-        setup_socket(&mut socket, param.if_name.as_deref(), max_queue_pairs > 1)?;
+    pub fn new(spec: TapNetSpec, name: impl Into<Arc<str>>) -> Result<Self> {
+        let mut socket = new_socket(spec.tap.as_deref(), matches!(spec.api, WorkerApi::IoUring))?;
+        let max_queue_pairs = max(spec.queue_pairs, 1);
+        setup_socket(&mut socket, spec.if_name.as_deref(), max_queue_pairs > 1)?;
         let mut dev_feat = NetFeature::MAC
             | NetFeature::MTU
             | NetFeature::CSUM
@@ -131,17 +128,17 @@ impl Net {
         let net = Net {
             name: name.into(),
             config: Arc::new(NetConfig {
-                mac: param.mac,
+                mac: spec.mac,
                 max_queue_pairs,
-                mtu: param.mtu,
+                mtu: spec.mtu,
                 ..Default::default()
             }),
             tap_sockets: vec![socket],
             feature: dev_feat,
             driver_feature: NetFeature::empty(),
-            dev_tap: param.tap,
-            if_name: param.if_name,
-            api: param.api,
+            dev_tap: spec.tap,
+            if_name: spec.if_name,
+            api: spec.api,
         };
         Ok(net)
     }

--- a/alioth/src/virtio/dev/net/vmnet.rs
+++ b/alioth/src/virtio/dev/net/vmnet.rs
@@ -47,7 +47,7 @@ use crate::sys::xpc::{
     xpc_dictionary_get_uint64, xpc_uint64_create,
 };
 use crate::virtio::dev::net::{NetConfig, NetFeature, VirtioNetHdr};
-use crate::virtio::dev::{DevParam, DeviceId, Result, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, DeviceId, Result, Virtio, WakeEvent};
 use crate::virtio::queue::{DescChain, QueueReg, Status, VirtQueue};
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{FEATURE_BUILT_IN, IrqSender};
@@ -76,8 +76,8 @@ fn check_ret(ret: VmnetReturn) -> Result<(), io::Error> {
 }
 
 impl Net {
-    pub fn new(param: NetVmnetParam, name: impl Into<Arc<str>>) -> Result<Self> {
-        let allocate_mac = param.mac.is_none();
+    pub fn new(spec: VmnetSpec, name: impl Into<Arc<str>>) -> Result<Self> {
+        let allocate_mac = spec.mac.is_none();
         let keys = unsafe {
             [
                 vmnet_operation_mode_key,
@@ -160,7 +160,7 @@ impl Net {
             Err(_) => Err(io::Error::other("failed to start vmnet interface").into()),
         }?;
 
-        if let Some(mac) = param.mac {
+        if let Some(mac) = spec.mac {
             config.mac = mac;
         }
 
@@ -454,12 +454,12 @@ fn write_to_vmnet(interface: *mut VmnetInterface) -> impl FnMut(&mut DescChain) 
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Help)]
-pub struct NetVmnetParam {
+pub struct VmnetSpec {
     /// MAC address of the virtual NIC, e.g. 06:3a:76:53:da:3d.
     pub mac: Option<MacAddr>,
 }
 
-impl DevParam for NetVmnetParam {
+impl DevSpec for VmnetSpec {
     type Device = Net;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<Self::Device> {

--- a/alioth/src/virtio/dev/vsock/uds_vsock.rs
+++ b/alioth/src/virtio/dev/vsock/uds_vsock.rs
@@ -40,7 +40,7 @@ use crate::virtio::dev::vsock::{
     ShutdownFlag, VSOCK_CID_HOST, VsockConfig, VsockFeature, VsockHeader, VsockOp, VsockType,
     VsockVirtq,
 };
-use crate::virtio::dev::{DevParam, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, Virtio, WakeEvent};
 use crate::virtio::queue::{DescChain, Queue, QueueReg, Status, VirtQueue};
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{DeviceId, FEATURE_BUILT_IN, IrqSender, Result, error};
@@ -49,14 +49,14 @@ const HEADER_SIZE: usize = size_of::<VsockHeader>();
 const SOCKET_TYPE: VsockType = VsockType::STREAM;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Help)]
-pub struct UdsVsockParam {
+pub struct UdsVsockSpec {
     /// Vsock context id.
     pub cid: u32,
     /// Host-side Unix domain socket path.
     pub path: Box<Path>,
 }
 
-impl DevParam for UdsVsockParam {
+impl DevSpec for UdsVsockSpec {
     type Device = UdsVsock;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<UdsVsock> {
@@ -668,15 +668,15 @@ pub struct Connection {
 }
 
 impl UdsVsock {
-    fn new(param: UdsVsockParam, name: impl Into<Arc<str>>) -> Result<Self> {
+    fn new(spec: UdsVsockSpec, name: impl Into<Arc<str>>) -> Result<Self> {
         let name = name.into();
-        let listener = UnixListener::bind(&param.path)?;
+        let listener = UnixListener::bind(&spec.path)?;
         listener.set_nonblocking(true)?;
         let vsock = UdsVsock {
             name,
-            path: param.path,
+            path: spec.path,
             config: Arc::new(VsockConfig {
-                guest_cid: param.cid,
+                guest_cid: spec.cid,
                 ..Default::default()
             }),
             listener,

--- a/alioth/src/virtio/dev/vsock/uds_vsock_test.rs
+++ b/alioth/src/virtio/dev/vsock/uds_vsock_test.rs
@@ -27,10 +27,10 @@ use crate::mem::emulated::{Action, Mmio};
 use crate::mem::mapped::Ram;
 use crate::sync::notifier::Notifier;
 use crate::virtio::dev::vsock::{
-    ShutdownFlag, UdsVsockParam, VSOCK_CID_HOST, VsockConfig, VsockFeature, VsockHeader, VsockOp,
+    ShutdownFlag, UdsVsockSpec, VSOCK_CID_HOST, VsockConfig, VsockFeature, VsockHeader, VsockOp,
     VsockType, VsockVirtq,
 };
-use crate::virtio::dev::{DevParam, StartParam, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, StartParam, Virtio, WakeEvent};
 use crate::virtio::queue::QueueReg;
 use crate::virtio::queue::split::SplitQueue;
 use crate::virtio::queue::tests::{GuestQueue, VirtQueueGuest};
@@ -118,7 +118,7 @@ fn vsock_conn_test() {
     let sock_path = temp_dir.path().join("vsock.sock");
 
     const GUEST_CID: u32 = 3;
-    let param = UdsVsockParam {
+    let param = UdsVsockSpec {
         cid: GUEST_CID,
         path: sock_path.clone().into(),
     };

--- a/alioth/src/virtio/dev/vsock/vhost_vsock.rs
+++ b/alioth/src/virtio/dev/vsock/vhost_vsock.rs
@@ -33,21 +33,21 @@ use crate::mem::mapped::RamBus;
 use crate::sync::notifier::Notifier;
 use crate::sys::vhost::{VHOST_FILE_UNBIND, VirtqAddr, VirtqFile, VirtqState};
 use crate::virtio::dev::vsock::{VsockConfig, VsockFeature};
-use crate::virtio::dev::{DevParam, DeviceId, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, DeviceId, Virtio, WakeEvent};
 use crate::virtio::queue::{QueueReg, VirtQueue};
 use crate::virtio::vhost::{UpdateVsockMem, VhostDev, error};
 use crate::virtio::worker::mio::{ActiveMio, Mio, VirtioMio};
 use crate::virtio::{IrqSender, Result, VirtioFeature};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Help)]
-pub struct VhostVsockParam {
+pub struct VhostVsockSpec {
     /// Vsock context id.
     pub cid: u32,
     /// Path to the host device file. [default: /dev/vhost-vsock]
     pub dev: Option<Box<Path>>,
 }
 
-impl DevParam for VhostVsockParam {
+impl DevSpec for VhostVsockSpec {
     type Device = VhostVsock;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<Self::Device> {
@@ -65,14 +65,14 @@ pub struct VhostVsock {
 }
 
 impl VhostVsock {
-    pub fn new(param: VhostVsockParam, name: impl Into<Arc<str>>) -> Result<VhostVsock> {
+    pub fn new(spec: VhostVsockSpec, name: impl Into<Arc<str>>) -> Result<VhostVsock> {
         let name = name.into();
-        let vhost_dev = match param.dev {
+        let vhost_dev = match spec.dev {
             Some(dev) => VhostDev::new(dev),
             None => VhostDev::new("/dev/vhost-vsock"),
         }?;
         vhost_dev.set_owner()?;
-        vhost_dev.vsock_set_guest_cid(param.cid as _)?;
+        vhost_dev.vsock_set_guest_cid(spec.cid as _)?;
         if let Ok(backend_feature) = vhost_dev.get_backend_features() {
             log::debug!("{name}: vhost-vsock backend feature: {backend_feature:x?}");
             vhost_dev.set_backend_features(&backend_feature)?;
@@ -90,7 +90,7 @@ impl VhostVsock {
             name,
             vhost_dev: Arc::new(vhost_dev),
             config: VsockConfig {
-                guest_cid: param.cid,
+                guest_cid: spec.cid,
                 ..Default::default()
             },
             features: known_feat as u64,

--- a/alioth/src/virtio/dev/vsock/vsock.rs
+++ b/alioth/src/virtio/dev/vsock/vsock.rs
@@ -22,9 +22,9 @@ use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 
 use crate::{bitflags, consts, impl_mmio_for_zerocopy};
 
-pub use self::uds_vsock::{UdsVsock, UdsVsockParam};
+pub use self::uds_vsock::{UdsVsock, UdsVsockSpec};
 #[cfg(target_os = "linux")]
-pub use self::vhost_vsock::{VhostVsock, VhostVsockParam};
+pub use self::vhost_vsock::{VhostVsock, VhostVsockSpec};
 
 consts! {
     pub struct VsockVirtq(u16) {

--- a/alioth/src/virtio/vu/frontend.rs
+++ b/alioth/src/virtio/vu/frontend.rs
@@ -30,7 +30,7 @@ use crate::mem::emulated::{Action, Mmio};
 use crate::mem::mapped::{ArcMemPages, RamBus};
 use crate::mem::{LayoutChanged, MemRegion};
 use crate::sync::notifier::Notifier;
-use crate::virtio::dev::{DevParam, Virtio, WakeEvent};
+use crate::virtio::dev::{DevSpec, Virtio, WakeEvent};
 use crate::virtio::queue::{QueueReg, VirtQueue};
 use crate::virtio::vu::bindings::{
     DeviceConfig, MemoryRegion, MemorySingleRegion, VirtqAddr, VirtqState, VuFeature,
@@ -429,12 +429,12 @@ impl VirtioMio for VuFrontend {
     }
 }
 
-pub struct VuFrontendParam {
+pub struct VuFrontendSpec {
     pub socket: Box<Path>,
     pub id: DeviceId,
 }
 
-impl DevParam for VuFrontendParam {
+impl DevSpec for VuFrontendSpec {
     type Device = VuFrontend;
 
     fn build(self, name: impl Into<Arc<str>>) -> Result<Self::Device> {

--- a/alioth/src/vm/vm.rs
+++ b/alioth/src/vm/vm.rs
@@ -29,14 +29,14 @@ use snafu::{ResultExt, Snafu};
 use crate::arch::layout::{PL011_START, PL031_START};
 #[cfg(target_arch = "x86_64")]
 use crate::arch::layout::{PORT_CMOS_REG, PORT_COM1, PORT_FW_CFG_SELECTOR, PORT_FWDBG};
-use crate::board::{Board, BoardConfig};
+use crate::board::{Board, BoardSpec};
 use crate::cpu::{Context, State, VcpuHandle, stop_vcpus, vcpu_thread};
 use crate::device::clock::SystemClock;
 #[cfg(target_arch = "x86_64")]
 use crate::device::cmos::Cmos;
 use crate::device::console::StdioConsole;
 #[cfg(target_arch = "x86_64")]
-use crate::device::fw_cfg::{FwCfg, FwCfgItemParam};
+use crate::device::fw_cfg::{FwCfg, FwCfgItemSpec};
 #[cfg(target_arch = "x86_64")]
 use crate::device::fw_dbg::FwDbg;
 #[cfg(target_arch = "aarch64")]
@@ -47,7 +47,7 @@ use crate::device::pl031::Pl031;
 use crate::device::serial::Serial;
 use crate::errors::{DebugTrace, trace_error};
 use crate::hv::{Hypervisor, IoeventFdRegistry, Vm};
-use crate::loader::Payload;
+use crate::loader::PayloadSpec;
 use crate::pci::pvpanic::PvPanic;
 use crate::pci::{Bdf, Pci};
 #[cfg(target_os = "linux")]
@@ -63,8 +63,8 @@ use crate::vfio::iommu::{Ioas, Iommu, UpdateIommuIoas};
 #[cfg(target_os = "linux")]
 use crate::vfio::pci::VfioPciDev;
 #[cfg(target_os = "linux")]
-use crate::vfio::{CdevParam, ContainerParam, GroupParam, IoasParam};
-use crate::virtio::dev::{DevParam, Virtio, VirtioDevice};
+use crate::vfio::{VfioCdevSpec, VfioContainerSpec, VfioGroupSpec, VfioIoasSpec};
+use crate::virtio::dev::{DevSpec, Virtio, VirtioDevice};
 use crate::virtio::pci::VirtioPciDevice;
 
 #[trace_error]
@@ -134,13 +134,13 @@ impl<H> Machine<H>
 where
     H: Hypervisor,
 {
-    pub fn new(hv: &H, config: BoardConfig) -> Result<Self> {
-        let ctx = Arc::new(Context::new(Board::new(hv, config)?));
+    pub fn new(hv: &H, spec: BoardSpec) -> Result<Self> {
+        let ctx = Arc::new(Context::new(Board::new(hv, spec)?));
 
         let (event_tx, event_rx) = flume::unbounded();
 
         let mut vcpus = ctx.vcpus.write();
-        for index in 0..ctx.board.config.cpu.count {
+        for index in 0..ctx.board.spec.cpu.count {
             let event_tx = event_tx.clone();
             let ctx = ctx.clone();
             let handle = thread::Builder::new()
@@ -235,10 +235,10 @@ where
     #[cfg(target_arch = "x86_64")]
     pub fn add_fw_cfg(
         &self,
-        params: impl Iterator<Item = FwCfgItemParam>,
+        specs: impl Iterator<Item = FwCfgItemSpec>,
     ) -> Result<Arc<Mutex<FwCfg>>, Error> {
-        let items = params
-            .map(|p| p.build())
+        let items = specs
+            .map(|spec| spec.build())
             .collect::<Result<Vec<_>, _>>()
             .context(error::FwCfg)?;
         let fw_cfg = Arc::new(Mutex::new(
@@ -253,18 +253,18 @@ where
     pub fn add_virtio_dev<D, P>(
         &self,
         name: impl Into<Arc<str>>,
-        param: P,
+        spec: P,
     ) -> Result<Arc<VirtioPciDev<H>>, Error>
     where
-        P: DevParam<Device = D>,
+        P: DevSpec<Device = D>,
         D: Virtio,
     {
-        if param.needs_mem_shared_fd() && !self.ctx.board.config.mem.has_shared_fd() {
+        if spec.needs_mem_shared_fd() && !self.ctx.board.spec.mem.has_shared_fd() {
             return error::MemNotSharedFd.fail();
         }
         let name = name.into();
         let bdf = self.ctx.board.pci_bus.reserve(None).unwrap();
-        let dev = param.build(name.clone())?;
+        let dev = spec.build(name.clone())?;
         if let Some(callback) = dev.mem_update_callback() {
             self.ctx.board.memory.register_update_callback(callback)?;
         }
@@ -276,7 +276,7 @@ where
             name.clone(),
             dev,
             self.ctx.board.memory.ram_bus(),
-            self.ctx.board.config.coco.is_some(),
+            self.ctx.board.spec.coco.is_some(),
         )?;
         let msi_sender = self.ctx.board.vm.create_msi_sender(
             #[cfg(target_arch = "aarch64")]
@@ -288,7 +288,7 @@ where
         Ok(dev)
     }
 
-    pub fn add_payload(&self, payload: Payload) {
+    pub fn add_payload(&self, payload: PayloadSpec) {
         *self.ctx.board.payload.write() = Some(payload)
     }
 }
@@ -300,16 +300,16 @@ where
 {
     const DEFAULT_NAME: &str = "default";
 
-    pub fn add_vfio_ioas(&self, param: IoasParam) -> Result<Arc<Ioas>, Error> {
+    pub fn add_vfio_ioas(&self, spec: VfioIoasSpec) -> Result<Arc<Ioas>, Error> {
         let mut ioases = self.vfio_ioases.lock();
-        if ioases.contains_key(&param.name) {
-            return error::AlreadyExists { name: param.name }.fail();
+        if ioases.contains_key(&spec.name) {
+            return error::AlreadyExists { name: spec.name }.fail();
         }
         let maybe_iommu = &mut *self.iommu.lock();
         let iommu = if let Some(iommu) = maybe_iommu {
             iommu.clone()
         } else {
-            let iommu_path = if let Some(dev_iommu) = &param.dev_iommu {
+            let iommu_path = if let Some(dev_iommu) = &spec.dev_iommu {
                 dev_iommu
             } else {
                 Path::new("/dev/iommu")
@@ -321,7 +321,7 @@ where
         let ioas = Arc::new(Ioas::alloc_on(iommu)?);
         let update = Box::new(UpdateIommuIoas { ioas: ioas.clone() });
         self.ctx.board.memory.register_change_callback(update)?;
-        ioases.insert(param.name, ioas.clone());
+        ioases.insert(spec.name, ioas.clone());
         Ok(ioas)
     }
 
@@ -331,7 +331,7 @@ where
             return Ok(ioas.clone());
         };
         if name.is_none() {
-            self.add_vfio_ioas(IoasParam {
+            self.add_vfio_ioas(VfioIoasSpec {
                 name: Self::DEFAULT_NAME.into(),
                 dev_iommu: None,
             })
@@ -340,10 +340,10 @@ where
         }
     }
 
-    pub fn add_vfio_cdev(&self, name: Arc<str>, param: CdevParam) -> Result<(), Error> {
-        let ioas = self.get_ioas(param.ioas.as_deref())?;
+    pub fn add_vfio_cdev(&self, name: Arc<str>, spec: VfioCdevSpec) -> Result<(), Error> {
+        let ioas = self.get_ioas(spec.ioas.as_deref())?;
 
-        let mut cdev = Cdev::new(&param.path)?;
+        let mut cdev = Cdev::new(&spec.path)?;
         cdev.attach_iommu_ioas(ioas.clone())?;
 
         let bdf = self.ctx.board.pci_bus.reserve(None).unwrap();
@@ -356,12 +356,12 @@ where
         Ok(())
     }
 
-    pub fn add_vfio_container(&self, param: ContainerParam) -> Result<Arc<Container>, Error> {
+    pub fn add_vfio_container(&self, spec: VfioContainerSpec) -> Result<Arc<Container>, Error> {
         let mut containers = self.vfio_containers.lock();
-        if containers.contains_key(&param.name) {
-            return error::AlreadyExists { name: param.name }.fail();
+        if containers.contains_key(&spec.name) {
+            return error::AlreadyExists { name: spec.name }.fail();
         }
-        let vfio_path = if let Some(dev_vfio) = &param.dev_vfio {
+        let vfio_path = if let Some(dev_vfio) = &spec.dev_vfio {
             dev_vfio
         } else {
             Path::new("/dev/vfio/vfio")
@@ -371,7 +371,7 @@ where
             container: container.clone(),
         });
         self.ctx.board.memory.register_change_callback(update)?;
-        containers.insert(param.name, container.clone());
+        containers.insert(spec.name, container.clone());
         Ok(container)
     }
 
@@ -381,7 +381,7 @@ where
             return Ok(container.clone());
         }
         if name.is_none() {
-            self.add_vfio_container(ContainerParam {
+            self.add_vfio_container(VfioContainerSpec {
                 name: Self::DEFAULT_NAME.into(),
                 dev_vfio: None,
             })
@@ -393,13 +393,13 @@ where
         }
     }
 
-    pub fn add_vfio_devs_in_group(&self, name: &str, param: GroupParam) -> Result<()> {
-        let container = self.get_container(param.container.as_deref())?;
-        let mut group = Group::new(&param.path)?;
+    pub fn add_vfio_devs_in_group(&self, name: &str, spec: VfioGroupSpec) -> Result<()> {
+        let container = self.get_container(spec.container.as_deref())?;
+        let mut group = Group::new(&spec.path)?;
         group.attach(container, VfioIommu::TYPE1_V2)?;
 
         let group = Arc::new(group);
-        for device in param.devices {
+        for device in spec.devices {
             let devfd = DevFd::new(group.clone(), &device)?;
             let name = format!("{name}-{device}");
             self.add_vfio_devfd(name.into(), devfd)?;


### PR DESCRIPTION
Rename various configuration and parameter structs across the codebase to use the 'Spec' suffix instead of 'Config' or 'Param'. This helps distinguish VM configurations from VirtIO device configurations which use 'Config' corresponding to the VirtIO standard.

Renamed:
- VmConfig -> VmSpec
- BoardConfig -> BoardSpec
- CpuConfig -> CpuSpec
- MemConfig -> MemSpec
- KvmConfig -> KvmSpec
- HvConfig -> HvSpec
- Payload -> PayloadSpec
- XxParam -> XxSpec (for devices and VFIO)

Updated all usages and tests.

Assisted-by: Antigravity:Gemini-3.5-Flash