### PR TITLE
Revert "ci: cache cargo llvm-cov build artifacts"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,9 +75,8 @@ jobs:
         env:
           RUST_LOG: "trace"
         run: |
-          cargo +nightly llvm-cov clean --workspace
           cargo +nightly llvm-cov test --target ${{ matrix.target.name }} --branch \
-              --no-clean --workspace --ignore-filename-regex '.*_test.rs$' \
+              --workspace --ignore-filename-regex '.*_test.rs$' \
               --lcov --output-path lcov-${{ matrix.target.name }}.info
       - name: Clippy
         run: cargo clippy --all-targets --target ${{ matrix.target.name }} -- -D warnings


### PR DESCRIPTION
This reverts commit 0691d1e0bb20b33224e8eb596bdd9978d35c5b09.

`cargo llvm-cov clean` followed by `cargo llvm-cov test --no-clean` is equivalent to `cargo llvm-cov test` without `--no-clean`.