### PR TITLE
fix(virtio): route invalid queue_sel in queue_notify_off to a reserved slot

### DIFF
--- a/alioth/src/virtio/pci.rs
+++ b/alioth/src/virtio/pci.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::min;
 use std::io::ErrorKind;
 use std::marker::PhantomData;
 use std::mem::size_of;
@@ -253,7 +254,9 @@ where
     E: IoeventFd,
 {
     fn size(&self) -> u64 {
-        (size_of::<VirtioPciRegister>() + size_of::<u32>() * self.queues.len()) as u64
+        // Reserve an extra 4-byte slot at the end of the notify capability to safely
+        // sink notifications from invalid/out-of-bounds queue indices.
+        (size_of::<VirtioPciRegister>() + size_of::<u32>() * (self.queues.len() + 1)) as u64
     }
 
     fn read(&self, offset: u64, size: u8) -> mem::Result<u64> {
@@ -315,7 +318,10 @@ where
                 }
             }
             VirtioCommonCfg::LAYOUT_QUEUE_NOTIFY_OFF => {
-                reg.queue_sel.load(Ordering::Acquire) as u64
+                let q_sel = reg.queue_sel.load(Ordering::Acquire);
+                // Route invalid queue indices to the additional reserved slot (self.queues.len())
+                // so guest MMIO writes do not access unmapped BAR memory or trigger valid queues.
+                min(q_sel, self.queues.len() as u16) as u64
             }
             VirtioCommonCfg::LAYOUT_QUEUE_DESC_LO => {
                 let q_sel = reg.queue_sel.load(Ordering::Relaxed);
@@ -706,24 +712,19 @@ where
 
         let msix_table_offset = 0;
         let msix_table_size = size_of::<MsixTableEntry>() * table_entries;
-
         let msix_pba_offset = 8 << 10;
-
-        let virtio_register_offset = 12 << 10;
-        let device_config_offset =
-            virtio_register_offset + size_of::<VirtioPciRegister>() + size_of::<u32>() * num_queues;
-
-        let msix_msg_ctrl = MsixMsgCtrl::new(table_entries as u16);
 
         let cap_msix = MsixCap {
             header: PciCapHdr {
                 id: PciCapId::MSIX,
                 ..Default::default()
             },
-            control: msix_msg_ctrl,
+            control: MsixMsgCtrl::new(table_entries as u16),
             table_offset: MsixCapOffset::new(msix_table_offset as u32, 0),
             pba_offset: MsixCapOffset::new(msix_pba_offset as u32, 0),
         };
+
+        let virtio_register_offset = 12 << 10;
         let cap_common = VirtioPciCap {
             header: PciCapHdr {
                 id: PciCapId::VENDOR,
@@ -761,11 +762,13 @@ where
                 bar: 0,
                 id: 0,
                 offset: (virtio_register_offset + VirtioPciRegister::OFFSET_QUEUE_NOTIFY) as u32,
-                length: (size_of::<u32>() * num_queues) as u32,
+                // Include an extra 4-byte slot to sink writes for invalid queue indices.
+                length: (size_of::<u32>() * (num_queues + 1)) as u32,
                 ..Default::default()
             },
             multiplier: size_of::<u32>() as u32,
         };
+        let device_config_offset = cap_notify.cap.offset + cap_notify.cap.length;
         let cap_device_config = VirtioPciCap {
             header: PciCapHdr {
                 id: PciCapId::VENDOR,

--- a/alioth/src/virtio/pci_test.rs
+++ b/alioth/src/virtio/pci_test.rs
@@ -22,9 +22,9 @@ use crate::hv::tests::TestMsiSender;
 use crate::mem::emulated::{Action, Mmio};
 use crate::pci::cap::MsixTableMmio;
 use crate::sync::notifier::Notifier;
-use crate::virtio::dev::Register;
+use crate::virtio::dev::{Register, WakeEvent};
 use crate::virtio::pci::{
-    PciIrqSender, VirtioCommonCfg, VirtioPciMsixVector, VirtioPciRegisterMmio,
+    PciIrqSender, VirtioCommonCfg, VirtioPciMsixVector, VirtioPciRegister, VirtioPciRegisterMmio,
 };
 use crate::virtio::queue::QueueReg;
 use crate::virtio::tests::FakeIoeventFd;
@@ -37,7 +37,7 @@ fn test_virtio_pci_queue_registers() {
         device: AtomicU64::new(0x0123_4567_89ab_cdef),
         ..Default::default()
     }]);
-    let (event_tx, _event_rx) = flume::unbounded();
+    let (event_tx, event_rx) = flume::unbounded();
     let notifier = Arc::new(Notifier::new().unwrap());
     let msi_sender = TestMsiSender::default();
     let msix_table = Arc::new(MsixTableMmio {
@@ -54,7 +54,7 @@ fn test_virtio_pci_queue_registers() {
     let mmio = VirtioPciRegisterMmio::<_, FakeIoeventFd> {
         name: "test-virtio-pci".into(),
         reg: Register::default(),
-        queues,
+        queues: queues.clone(),
         irq_sender,
         ioeventfds: None,
         event_tx,
@@ -133,4 +133,30 @@ fn test_virtio_pci_queue_registers() {
             .unwrap(),
         0xffff
     );
+
+    // Valid queue notify (to valid queue offset) wakes up the queue
+    assert_matches!(
+        mmio.write(VirtioPciRegister::OFFSET_QUEUE_NOTIFY as u64, 2, 0),
+        Ok(Action::None)
+    );
+    assert_matches!(event_rx.try_recv(), Ok(WakeEvent::Notify { q_index: 0 }));
+
+    // Queue notify offset for out of bounds queue returns the reserved slot (queues.len())
+    assert_matches!(
+        mmio.write(VirtioCommonCfg::LAYOUT_QUEUE_SELECT.0 as u64, 2, 0xffff),
+        Ok(Action::None)
+    );
+    assert_matches!(
+        mmio.read(VirtioCommonCfg::LAYOUT_QUEUE_NOTIFY_OFF.0 as u64, 2),
+        Ok(1)
+    );
+
+    // Queue notify to reserved invalid slot does not wake up any queue
+    let invalid_notify_offset =
+        VirtioPciRegister::OFFSET_QUEUE_NOTIFY + size_of::<u32>() * queues.len();
+    assert_matches!(
+        mmio.write(invalid_notify_offset as u64, 2, 0),
+        Ok(Action::None)
+    );
+    assert!(event_rx.is_empty());
 }


### PR DESCRIPTION
When a driver selects an out-of-bounds queue index (queue_sel >= num_queues) and reads LAYOUT_QUEUE_NOTIFY_OFF, returning queue_sel as-is causes the driver to calculate a notify address past the mapped BAR memory, resulting in an undefined behavior.

Allocate an additional 4-byte slot at the end of the notify capability and MMIO region, and return min(queue_sel, num_queues) for LAYOUT_QUEUE_NOTIFY_OFF. This routes invalid queue notifications to the reserved slot, which is safely ignored by the MMIO handler without accessing unmapped memory or falsely triggering valid queues.